### PR TITLE
Add the `config --set` command to update the `lla` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ lla init
 lla config # to view the config file
 ```
 
+You can modify configuration values using the `config --set` command:
+
+```bash
+lla config --set plugins_dir /new/path/to/plugins  # Change plugins directory
+lla config --set default_sort size                 # Change default sort
+lla config --set default_format long              # Change default format
+lla config --set default_depth 5                  # Change default depth
+```
+
 Example configuration:
 
 ```toml

--- a/lla/Cargo.lock
+++ b/lla/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lla"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "clap",

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lla"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "A lightweight ls replacement"
 authors = ["Achaq <hi@achaq.dev>"]

--- a/lla/src/config/mod.rs
+++ b/lla/src/config/mod.rs
@@ -114,3 +114,27 @@ pub fn view_config() -> Result<(), LlaError> {
     println!("{:#?}", config);
     Ok(())
 }
+
+pub fn update_config(key: &str, value: &str) -> Result<(), LlaError> {
+    let config_path = Config::get_config_path();
+    let mut config = Config::load(&config_path).map_err(LlaError::Io)?;
+
+    match key {
+        "plugins_dir" => {
+            config.plugins_dir = PathBuf::from(value);
+            config.ensure_plugins_dir().map_err(LlaError::Io)?;
+        }
+        "default_sort" => config.default_sort = value.to_string(),
+        "default_format" => config.default_format = value.to_string(),
+        "default_depth" => {
+            config.default_depth = Some(value.parse().map_err(|_| {
+                LlaError::Config(format!("Invalid value for default_depth: {}", value))
+            })?);
+        }
+        _ => return Err(LlaError::Config(format!("Unknown config key: {}", key))),
+    }
+
+    config.save(&config_path).map_err(LlaError::Io)?;
+    println!("Updated {} to {}", key, value);
+    Ok(())
+}

--- a/lla/src/main.rs
+++ b/lla/src/main.rs
@@ -9,7 +9,7 @@ mod plugin;
 mod sorter;
 mod utils;
 
-use args::{Args, Command, InstallSource};
+use args::{Args, Command, ConfigAction, InstallSource};
 use config::{initialize_config, Config};
 use error::{LlaError, Result};
 use filter::{ExtensionFilter, FileFilter, PatternFilter};
@@ -43,10 +43,14 @@ fn main() -> Result<()> {
         }
         Some(Command::ListPlugins) => list_plugins(&plugin_manager),
         Some(Command::InitConfig) => initialize_config(),
+        Some(Command::Config(action)) => match action {
+            Some(ConfigAction::View) => config::view_config(),
+            Some(ConfigAction::Set(key, value)) => config::update_config(&key, &value),
+            None => config::view_config(),
+        },
         Some(Command::PluginAction(plugin_name, action, action_args)) => {
             plugin_manager.perform_plugin_action(&plugin_name, &action, &action_args)
         }
-        Some(Command::Config) => Ok(config::view_config()?),
         None => {
             if let Some(error) = config_error {
                 eprintln!("Warning: {}", error);


### PR DESCRIPTION
This pull request introduces several enhancements to the configuration management of the `lla` project, including the ability to modify configuration values via command line. The changes span multiple files, primarily focusing on extending the `config` command functionality.

Configuration management improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R113-R121): Added documentation for modifying configuration values using the `config --set` command.

* [`lla/src/args.rs`](diffhunk://#diff-cd27c8ded21d32a69113683cccb7addf34dc5db626023e82c63757a1ea44612bL24-R24): Updated the `Config` command to accept an optional `ConfigAction` argument, allowing for viewing or setting configuration values. Introduced the `ConfigAction` enum to handle different configuration actions. [[1]](diffhunk://#diff-cd27c8ded21d32a69113683cccb7addf34dc5db626023e82c63757a1ea44612bL24-R24) [[2]](diffhunk://#diff-cd27c8ded21d32a69113683cccb7addf34dc5db626023e82c63757a1ea44612bR33-R37) [[3]](diffhunk://#diff-cd27c8ded21d32a69113683cccb7addf34dc5db626023e82c63757a1ea44612bL158-R174) [[4]](diffhunk://#diff-cd27c8ded21d32a69113683cccb7addf34dc5db626023e82c63757a1ea44612bL191-R216)

* [`lla/src/config/mod.rs`](diffhunk://#diff-f9ad0af36035815784d031019838b9125aa2a98ae85924693b84c541b96ef530R117-R140): Added the `update_config` function to handle updating configuration values and saving them to the configuration file.

* [`lla/src/main.rs`](diffhunk://#diff-c3f4a663a96cf92bb31419aa864e13395c5d8f38fab29aa92b3806d1123cdcdbL12-R12): Modified the main function to handle the new `ConfigAction` variants, enabling the viewing and setting of configuration values. [[1]](diffhunk://#diff-c3f4a663a96cf92bb31419aa864e13395c5d8f38fab29aa92b3806d1123cdcdbL12-R12) [[2]](diffhunk://#diff-c3f4a663a96cf92bb31419aa864e13395c5d8f38fab29aa92b3806d1123cdcdbR46-L49)

Version update:

* [`lla/Cargo.toml`](diffhunk://#diff-0ec5174e2de4812ad86d11236ad67495bf51a633297d75aad04321eab2eab5d5L3-R3): Bumped the version from `0.2.6` to `0.2.7` to reflect the new features.