### PR TITLE
feat: add directory indicator #11

### DIFF
--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 pub fn colorize_file_name(path: &Path) -> ColoredString {
     let name = path.file_name().unwrap().to_str().unwrap();
     if path.is_dir() {
-        name.bright_blue().bold()
+        format!("{}/", name).bright_blue().bold()
     } else if path.is_symlink() {
         name.bright_cyan().italic()
     } else if is_executable(path) {
@@ -39,10 +39,15 @@ use std::os::unix::fs::PermissionsExt;
 
 pub fn colorize_permissions(permissions: &Permissions) -> String {
     let mode = permissions.mode();
+    let file_type = if mode & 0o40000 != 0 {
+        "d".bright_blue()
+    } else {
+        "-".bright_black()
+    };
     let user = triplet(mode, 6);
     let group = triplet(mode, 3);
     let other = triplet(mode, 0);
-    format!("{}{}{}", user, group, other)
+    format!("{}{}{}{}", file_type, user, group, other)
 }
 
 fn triplet(mode: u32, shift: u32) -> String {


### PR DESCRIPTION
This pull request includes changes to the `lla/src/utils/color.rs` file to enhance the colorization of file names and permissions. The most important changes include modifying the colorization of directory names and adding file type indicators to the permissions string.

Enhancements to colorization:

* [`lla/src/utils/color.rs`](diffhunk://#diff-16281513af115f7f8b4a8c196c2ea5e3d27683c34cc14ff9735b0359ad8a2ea6L7-R7): Updated the `colorize_file_name` function to append a slash to directory names before applying colorization.
* [`lla/src/utils/color.rs`](diffhunk://#diff-16281513af115f7f8b4a8c196c2ea5e3d27683c34cc14ff9735b0359ad8a2ea6R42-R50): Modified the `colorize_permissions` function to include a file type indicator at the beginning of the permissions string, with directories indicated in bright blue and regular files in bright black.