### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,26 @@
 name: Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   check_release:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    if: |
+      (github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner) ||
+      (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       should_release: ${{ steps.check_version.outputs.should_release }}
       current_version: ${{ steps.check_version.outputs.current_version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check version changes
         id: check_version


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow to improve the release process. The most important changes include modifying the trigger event for pull requests, adding a manual trigger option, and updating the job conditions and permissions.

Changes to GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R23): Changed the trigger event from `pull_request` to `pull_request_target` and added `workflow_dispatch` to allow manual triggering of the workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R23): Updated the job condition to include a check for manual workflow dispatch by the repository owner.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R23): Added `contents: write` permission to the job to allow necessary write operations.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R23): Set `fetch-depth` to 0 in the `actions/checkout` step to ensure the entire repository history is fetched.