### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check_release:
     if: |
-      (github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner) ||
+      (github.event_name == 'workflow_dispatch' && github.actor == github.repository.owner.login) ||
       (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     permissions:
@@ -28,10 +28,13 @@ jobs:
           git fetch origin main
 
           # Get the version from the main branch's Cargo.toml
-          OLD_VERSION=$(git show origin/main:Cargo.toml | grep '^version =' | cut -d '"' -f 2)
+          OLD_VERSION=$(git show origin/main:Cargo.toml | sed -n '/^\[workspace\.package\]/,/^$/p' | grep '^version = ' | cut -d '"' -f 2)
 
           # Get the current version from Cargo.toml
-          CURRENT_VERSION=$(grep '^version =' Cargo.toml | cut -d '"' -f 2)
+          CURRENT_VERSION=$(sed -n '/^\[workspace\.package\]/,/^$/p' Cargo.toml | grep '^version = ' | cut -d '"' -f 2)
+
+          echo "Old version: $OLD_VERSION"
+          echo "Current version: $CURRENT_VERSION"
 
           if [ "$OLD_VERSION" != "$CURRENT_VERSION" ]; then
             echo "Version changed from $OLD_VERSION to $CURRENT_VERSION"


### PR DESCRIPTION
This pull request includes updates to the `release.yml` workflow file to improve the version extraction logic and correct the condition for checking the repository owner.

Changes in `release.yml`:

* Corrected the condition to check the repository owner's login in the `check_release` job. (`.github/workflows/release.yml`)
* Updated the version extraction logic to correctly parse the version from the `Cargo.toml` file within the `[workspace.package]` section. (`.github/workflows/release.yml`)