### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check_release:
     if: |
-      (github.event_name == 'workflow_dispatch' && github.actor == github.repository.owner.login) ||
+      (github.event_name == 'workflow_dispatch' && github.actor == 'triyanox') ||
       (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     permissions:
@@ -28,10 +28,10 @@ jobs:
           git fetch origin main
 
           # Get the version from the main branch's Cargo.toml
-          OLD_VERSION=$(git show origin/main:Cargo.toml | sed -n '/^\[workspace\.package\]/,/^$/p' | grep '^version = ' | cut -d '"' -f 2)
+          OLD_VERSION=$(git show origin/main:Cargo.toml | sed -n '/^\[workspace\.package\]/,/^\[/p' | grep '^version = ' | cut -d '"' -f 2)
 
           # Get the current version from Cargo.toml
-          CURRENT_VERSION=$(sed -n '/^\[workspace\.package\]/,/^$/p' Cargo.toml | grep '^version = ' | cut -d '"' -f 2)
+          CURRENT_VERSION=$(sed -n '/^\[workspace\.package\]/,/^\[/p' Cargo.toml | grep '^version = ' | cut -d '"' -f 2)
 
           echo "Old version: $OLD_VERSION"
           echo "Current version: $CURRENT_VERSION"
@@ -43,6 +43,7 @@ jobs:
           else
             echo "Version unchanged"
             echo "should_release=false" >> $GITHUB_OUTPUT
+            echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           fi
 
   publish:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to improve the release workflow. The most important changes include modifying conditions for triggering the release job, updating the method to fetch version numbers from `Cargo.toml`, and adding an output for the current version when the version is unchanged.

Changes to release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L12-R12): Modified the condition to trigger the release job to check if the actor is 'triyanox' instead of the repository owner.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R34): Updated the `sed` command to fetch the version numbers from `Cargo.toml` to handle sections more accurately.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R46): Added an output for the current version when the version is unchanged.