### PR TITLE
chore: fix the syncing issue on the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,12 +132,27 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Publish to crates.io
+      - name: Update dependency version
+        run: |
+          VERSION="${{ needs.check_release.outputs.current_version }}"
+          # Update the version in lla/Cargo.toml
+          sed -i 's/version = "[0-9]*\.[0-9]*\.[0-9]*"/version = "'$VERSION'"/' lla/Cargo.toml
+
+      - name: Check and publish to crates.io
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
-          cargo publish -p lla_plugin_interface
-          # Wait for crates.io indexing
-          sleep 30
+
+          # Check if lla_plugin_interface version already exists
+          if ! cargo search lla_plugin_interface --limit 1 | grep -q "lla_plugin_interface = \"${{ needs.check_release.outputs.current_version }}\""; then
+            echo "Publishing lla_plugin_interface v${{ needs.check_release.outputs.current_version }}"
+            cargo publish -p lla_plugin_interface
+            # Wait for crates.io indexing
+            sleep 60
+          else
+            echo "lla_plugin_interface v${{ needs.check_release.outputs.current_version }} already published, skipping..."
+          fi
+
+          echo "Publishing lla v${{ needs.check_release.outputs.current_version }}"
           cargo publish -p lla
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to improve the release process by updating the dependency version before publishing to crates.io and adding a check to avoid publishing already existing versions.

Improvements to the release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L135-R155): Added a step to update the version in `lla/Cargo.toml` before publishing.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L135-R155): Added a check to see if the `lla_plugin_interface` version already exists on crates.io to avoid republishing it.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L135-R155): Increased the sleep duration after publishing `lla_plugin_interface` to ensure crates.io indexing completes.