### PR TITLE
chore: fix version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,17 +142,22 @@ jobs:
         run: |
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
 
-          # Check if lla_plugin_interface version already exists
-          if ! cargo search lla_plugin_interface --limit 1 | grep -q "lla_plugin_interface = \"${{ needs.check_release.outputs.current_version }}\""; then
-            echo "Publishing lla_plugin_interface v${{ needs.check_release.outputs.current_version }}"
+          # Get current version without 'v' prefix
+          VERSION="${{ needs.check_release.outputs.current_version }}"
+
+          # Check if lla_plugin_interface version exists (using awk to get just the version)
+          PUBLISHED_VERSION=$(cargo search lla_plugin_interface --limit 1 | awk -F '"' '{print $2}')
+
+          if [ "$PUBLISHED_VERSION" != "$VERSION" ]; then
+            echo "Publishing lla_plugin_interface v$VERSION"
             cargo publish -p lla_plugin_interface
             # Wait for crates.io indexing
-            sleep 60
+            sleep 30
           else
-            echo "lla_plugin_interface v${{ needs.check_release.outputs.current_version }} already published, skipping..."
+            echo "lla_plugin_interface v$VERSION already published, skipping..."
           fi
 
-          echo "Publishing lla v${{ needs.check_release.outputs.current_version }}"
+          echo "Publishing lla v$VERSION"
           cargo publish -p lla
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to improve the release process for the `lla_plugin_interface`. The most important changes include modifying the version check mechanism and reducing the waiting time for crates.io indexing.

Improvements to release process:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L145-R160): Changed the method of checking if the `lla_plugin_interface` version exists by using `awk` to extract the version, ensuring more accurate version comparison.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L145-R160): Reduced the waiting time for crates.io indexing from 60 seconds to 30 seconds to expedite the release process.