### PR TITLE
chore: add explicit version for `lla_plugin_interface`

### DIFF
--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -26,4 +26,4 @@ serde_json.workspace = true
 walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
-lla_plugin_interface = { workspace = true, version = "0.2.9" }
+lla_plugin_interface = { version = "0.2.9", path = "lla_plugin_interface" }


### PR DESCRIPTION
This pull request includes a change to the `lla/Cargo.toml` file to adjust the configuration for the `lla_plugin_interface` dependency.

* [`lla/Cargo.toml`](diffhunk://#diff-0ec5174e2de4812ad86d11236ad67495bf51a633297d75aad04321eab2eab5d5L29-R29): Modified the `lla_plugin_interface` dependency to use a specified path instead of the workspace configuration.