### PR TITLE
chore: fix path for `lla_plugin_interface`

### DIFF
--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -26,4 +26,4 @@ serde_json.workspace = true
 walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
-lla_plugin_interface = { version = "0.2.9", path = "lla_plugin_interface" }
+lla_plugin_interface = { version = "0.2.9", path = "../lla_plugin_interface" }


### PR DESCRIPTION
This pull request includes a change to the `lla/Cargo.toml` file to update the path for the `lla_plugin_interface` dependency.

Dependency path update:

* [`lla/Cargo.toml`](diffhunk://#diff-0ec5174e2de4812ad86d11236ad67495bf51a633297d75aad04321eab2eab5d5L29-R29): Changed the path of `lla_plugin_interface` from `"lla_plugin_interface"` to `"../lla_plugin_interface"`.