### PR TITLE
Add `Homebrew` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ paru -S lla
 
 (btw)
 
+### For macOS users with Homebrew
+
+[`lla`](https://formulae.brew.sh/formula/lla#default) is available in the [Homebrew](https://brew.sh) package manager. You can install it with:
+
+```bash
+brew install lla
+```
+
 ## Usage
 
 First you need to initialize the configuration file:


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds installation instructions for macOS users with Homebrew.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R69): Added a new section with instructions for installing `lla` using Homebrew on macOS.