### PR TITLE
feat: enhance plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,10 +304,13 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "colored",
+ "lazy_static",
  "lla_plugin_interface",
+ "parking_lot",
+ "rayon",
  "walkdir",
 ]
 
@@ -442,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "git_status"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "colored",
  "lla_plugin_interface",

--- a/plugins/dirs/Cargo.toml
+++ b/plugins/dirs/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "dirs"
 description = "Shows directories metadata"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
 colored = "2.0.0"
 walkdir = "2.3.2"
 lla_plugin_interface = { path = "../../lla_plugin_interface" }
+rayon = "1.8"
+lazy_static = "1.4"
+parking_lot = "0.12"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/git_status/Cargo.toml
+++ b/plugins/git_status/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git_status"
 description = "Shows the git status of each file"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This pull request includes several changes to the `dirs` and `git_status` plugins to improve their functionality and performance. The changes include updating dependencies, adding caching mechanisms, and improving the efficiency of existing methods.

### Improvements to `dirs` plugin:

* Updated version to `0.2.1` and added new dependencies: `rayon`, `lazy_static`, and `parking_lot` in `Cargo.toml`.
* Added caching mechanism to store directory statistics using `lazy_static` and `RwLock` in `lib.rs`.
* Modified `analyze_directory` method to use parallel iteration with `rayon` and cache results to improve performance.
* Enhanced the `EntryDecorator` implementation to display the last modified time of directories in a human-readable format.

### Improvements to `git_status` plugin:

* Updated version to `0.2.1` in `Cargo.toml`.
* Refactored `is_git_repo` method to use a more idiomatic approach with `Option` and `while let`.
* Improved `get_git_status` method to handle paths more robustly and streamline command execution.
* Simplified `format_git_status` method to handle status characters more effectively and use fewer allocations.