### PR TITLE
Support themes and more package managers and more

### DIFF
--- a/.github/workflows/package-managers.yml
+++ b/.github/workflows/package-managers.yml
@@ -1,0 +1,191 @@
+name: Package Manager Distribution
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  macports:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MacPorts port
+        run: |
+          # Create MacPorts Portfile
+          mkdir -p macports/lla
+          cat > macports/lla/Portfile << EOF
+          # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+          PortSystem          1.0
+          PortGroup           github 1.0
+          PortGroup           cargo 1.0
+
+          github.setup        triyanox lla \${version}
+          categories          devel
+          platforms           darwin
+          license            MIT
+          maintainers        github:triyanox
+          description        A modern and extensible log analysis CLI tool
+          long_description   \${description}
+
+          checksums           \${checksums}
+
+          cargo.crates        \${crates}
+          EOF
+
+      - name: Create Pull Request for MacPorts
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "port lla: update to ${{ github.event.release.tag_name }}"
+          title: "port lla: update to ${{ github.event.release.tag_name }}"
+          body: |
+            Update lla port to version ${{ github.event.release.tag_name }}
+          branch: update-macports
+          base: master
+
+      - name: Create PR in MacPorts
+        run: |
+          gh repo fork macports/macports-ports --clone=false
+          gh pr create --repo macports/macports-ports \
+            --title "port lla: update to ${{ github.event.release.tag_name }}" \
+            --body "Update lla port to version ${{ github.event.release.tag_name }}" \
+            --base master \
+            --head triyanox:update-macports
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  scoop:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Scoop manifest
+        run: |
+          mkdir -p scoop
+          # Create manifest file
+          cat > scoop/lla.json << EOF
+          {
+              "version": "${{ github.event.release.tag_name }}",
+              "description": "A modern and extensible log analysis CLI tool",
+              "homepage": "https://github.com/triyanox/lla",
+              "license": "MIT",
+              "architecture": {
+                  "64bit": {
+                      "url": "https://github.com/triyanox/lla/releases/download/${{ github.event.release.tag_name }}/lla-windows-amd64.exe",
+                      "bin": "lla-windows-amd64.exe"
+                  }
+              },
+              "autoupdate": {
+                  "architecture": {
+                      "64bit": {
+                          "url": "https://github.com/triyanox/lla/releases/download/v$version/lla-windows-amd64.exe"
+                      }
+                  }
+              }
+          }
+          EOF
+
+      - name: Create Pull Request for Scoop
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "lla: update to ${{ github.event.release.tag_name }}"
+          title: "lla: update to ${{ github.event.release.tag_name }}"
+          body: |
+            Update lla to version ${{ github.event.release.tag_name }}
+          branch: update-scoop
+          base: master
+
+      - name: Create PR in Scoop
+        run: |
+          gh repo fork ScoopInstaller/Main --clone=false
+          gh pr create --repo ScoopInstaller/Main \
+            --title "lla: update to ${{ github.event.release.tag_name }}" \
+            --body "Update lla to version ${{ github.event.release.tag_name }}" \
+            --base master \
+            --head triyanox:update-scoop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  winget:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Winget manifest
+        run: |
+          mkdir -p winget-manifests/l/lla/lla
+          cat > winget-manifests/l/lla/lla/manifest.yaml << EOF
+          PackageIdentifier: lla.lla
+          PackageVersion: ${{ github.event.release.tag_name }}
+          PackageName: lla
+          Publisher: triyanox
+          License: MIT
+          ShortDescription: A modern and extensible log analysis CLI tool
+          PackageUrl: https://github.com/triyanox/lla
+          Installers:
+            - Architecture: x64
+              InstallerUrl: https://github.com/triyanox/lla/releases/download/${{ github.event.release.tag_name }}/lla-windows-amd64.exe
+              InstallerType: portable
+              InstallerSha256: ${{ github.event.release.assets[0].sha256 }}
+          ManifestType: singleton
+          ManifestVersion: 1.0.0
+          EOF
+
+      - name: Create PR in Winget
+        run: |
+          gh repo fork microsoft/winget-pkgs --clone=false
+          gh pr create --repo microsoft/winget-pkgs \
+            --title "Add lla ${{ github.event.release.tag_name }}" \
+            --body "Add lla version ${{ github.event.release.tag_name }}" \
+            --base master \
+            --head triyanox:add-lla
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Nix package
+        run: |
+          mkdir -p nixpkgs
+          cat > nixpkgs/default.nix << EOF
+          { lib, rustPlatform, fetchFromGitHub }:
+
+          rustPlatform.buildRustPackage rec {
+            pname = "lla";
+            version = "${{ github.event.release.tag_name }}";
+
+            src = fetchFromGitHub {
+              owner = "triyanox";
+              repo = "lla";
+              rev = "v\${version}";
+              sha256 = "0000000000000000000000000000000000000000000000000000";
+            };
+
+            cargoSha256 = "0000000000000000000000000000000000000000000000000000";
+
+            meta = with lib; {
+              description = "A modern and extensible log analysis CLI tool";
+              homepage = "https://github.com/triyanox/lla";
+              license = licenses.mit;
+              maintainers = with maintainers; [ triyanox ];
+            };
+          }
+          EOF
+
+      - name: Create PR in Nixpkgs
+        run: |
+          gh repo fork NixOS/nixpkgs --clone=false
+          gh pr create --repo NixOS/nixpkgs \
+            --title "lla: init at ${{ github.event.release.tag_name }}" \
+            --body "Add lla package version ${{ github.event.release.tag_name }}" \
+            --base master \
+            --head triyanox:add-lla
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,17 @@ jobs:
             target: aarch64-apple-darwin
             artifact_name: lla-macos-arm64
 
+          # Windows builds
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: lla-windows-amd64.exe
+          - os: windows-latest
+            target: i686-pc-windows-msvc
+            artifact_name: lla-windows-i686.exe
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            artifact_name: lla-windows-arm64.exe
+
     steps:
       - uses: actions/checkout@v4
 
@@ -112,7 +123,11 @@ jobs:
 
       - name: Prepare binary
         run: |
-          cp target/${{ matrix.target }}/release/lla ${{ matrix.artifact_name }}
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp target/${{ matrix.target }}/release/lla.exe ${{ matrix.artifact_name }}
+          else
+            cp target/${{ matrix.target }}/release/lla ${{ matrix.artifact_name }}
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2024-12-16
+
+### Added
+
+- A theming system to customize the look of `lla`
+- New configuration option `theme`
+- An extensive theming preset library
+- Add the `--no-color` flag to disable color output, and works will all listing formats
+- New package managers support:
+
+  - Flatpak
+  - Debian
+  - Scoop
+  - Winget
+
+- Include window builds in the releases
+
+### Fixed
+
+- Minor fixes and improvements
+- Stability improvements
+
 ## [0.3.4] - 2024-12-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lla"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "atty",
  "bytes",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "lla_plugin_interface"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["lla", "lla_plugin_interface", "plugins/*"]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Achaq <hi@achaq.dev>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [Filter System](#filter-system)
   - [Plugin System](#plugin-system)
 - [Configuration](#configuration)
+- [Theming](#theming)
 - [Development](#development)
   - [Plugin Development](#plugin-development)
   - [Contributing](#contributing)
@@ -467,6 +468,61 @@ CLI Configuration:
 lla config --set default_sort size
 lla config --set default_format long
 ```
+
+## Theming
+
+LLA includes a powerful theming system that allows you to customize the appearance of your file listings. Themes are defined in TOML files and stored in `~/.config/lla/themes/`.
+
+**Built-in Themes:**
+
+- **default**: Traditional terminal colors
+- **dark**: Modern dark theme optimized for dark terminals
+- **light**: Clean theme optimized for light terminals
+- **poimandres**: Theme inspired by the Poimandres color scheme
+
+**Using Themes:**
+
+```bash
+# Set theme in config
+lla config --set theme dark
+
+# Disable colors
+lla config --set theme none
+# Or use --no-colors flag
+lla --no-colors
+```
+
+**Theme Structure:**
+
+```toml
+# Theme metadata
+name = "my_theme"
+author = "Your Name"
+description = "A description of your theme"
+
+# Core colors
+[colors]
+file = "#FFFFFF"        # Regular files
+directory = "#89AFFF"   # Directories
+symlink = "#89DBFF"     # Symbolic links
+executable = "#5DE4B3"  # Executable files
+
+# Special files
+[special_files.folders]
+"node_modules" = "#666666"
+".git" = "#FF6B6B"
+
+[special_files.dotfiles]
+".gitignore" = "#89DBFF"
+".env" = "#FFFFC2"
+
+# Extension-based colors
+[extensions.groups]
+rust = ["rs", "toml"]
+web = ["html", "css", "js"]
+```
+
+For more detailed information about theming, see the [themes documentation](themes/README.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -473,36 +473,6 @@ lla config --set default_format long
 
 LLA includes a powerful theming system that allows you to customize the appearance of your file listings. Themes are defined in TOML files and stored in `~/.config/lla/themes/`.
 
-**Built-in Themes:**
-
-- **default**: Traditional terminal colors with carefully selected colors for optimal visibility
-- **dark**: Modern dark theme with enhanced visibility and rich colors for dark terminals
-- **light**: Clean theme optimized for light terminals with maximum readability
-- **ayu_dark**: Dark theme inspired by the Ayu Dark color scheme, featuring deep backgrounds and vibrant accents
-- **ayu_light**: Light theme with carefully selected colors for optimal readability
-- **ayu_mirage**: Refined dark theme with muted colors and soft contrasts
-- **catppuccin_mocha**: A soothing pastel theme for the high-spirited, featuring warm, cozy colors
-- **dracula**: Classic Dracula color scheme with vibrant colors and high contrast
-- **gruvbox_dark**: Retro groove color scheme with warm, earthy tones and high contrast
-- **material_ocean**: Deep blue theme based on Material Design, featuring oceanic colors
-- **nord**: Arctic, north-bluish color palette with elegant pastel colors
-- **one_dark**: Dark theme inspired by Atom, featuring a perfect balance of cool and warm colors
-- **poimandres**: Deep space aesthetic with vibrant accents
-- **tokyo_night**: Dark theme inspired by the vibrant lights of Tokyo at night
-- **vesper**: Minimalist dark theme with warm accents
-
-**Using Themes:**
-
-```bash
-# Set theme in config
-lla config --set theme dark
-
-# Disable colors
-lla config --set theme none
-# Or use --no-colors flag
-lla --no-colors
-```
-
 **Theme Structure:**
 
 ```toml
@@ -519,18 +489,56 @@ symlink = "#89DBFF"     # Symbolic links
 executable = "#5DE4B3"  # Executable files
 
 # Special files
-[special_files.folders]
-"node_modules" = "#666666"
-".git" = "#FF6B6B"
-
-[special_files.dotfiles]
-".gitignore" = "#89DBFF"
-".env" = "#FFFFC2"
+[special_files]
+folders."node_modules" = "#666666"
+dotfiles.".env" = "#FFFFC2"
+exact_match."README.md" = "#FFFFC2"
+patterns."*.min.*" = "#282E30"
 
 # Extension-based colors
 [extensions.groups]
 rust = ["rs", "toml"]
 web = ["html", "css", "js"]
+
+[extensions.colors]
+rust = "#FF5733"
+web = "#61AFEF"
+```
+
+**Built-in Themes:**
+
+- **default**: Traditional terminal colors optimized for visibility
+- **dark**: Modern dark theme with enhanced visibility
+- **light**: Clean theme optimized for light terminals
+- **ayu_dark**, **ayu_light**, **ayu_mirage**: Inspired by the Ayu color scheme
+- **catppuccin_mocha**: Soothing pastel theme with warm colors
+- **dracula**: Classic Dracula scheme with vibrant colors
+- **gruvbox_dark**: Retro groove theme with earthy tones
+- **material_ocean**: Deep blue Material Design theme
+- **nord**: Arctic, north-bluish color palette
+- **one_dark**: Atom-inspired balanced dark theme
+- **poimandres**: Deep space aesthetic theme
+- **tokyo_night**: Vibrant dark theme inspired by Tokyo nights
+- **vesper**: Minimalist dark theme with warm accents
+
+**Using Themes:**
+
+Copy the theme you want to use to your `~/.config/lla/themes/` directory.
+
+and then set the theme in your config or use the command line:
+
+```bash
+# Set theme in config
+lla config --set theme dark
+
+# Disable colors
+lla config --set theme none
+```
+
+also you can disable colors all together by using the `--no-colors` flag:
+
+```bash
+lla --no-colors # works with all listing commands
 ```
 
 For more detailed information about theming, see the [themes documentation](themes/README.md).
@@ -548,6 +556,10 @@ Develop custom plugins using the `Plugin` trait from [lla_plugin_interface](http
 3. Commit your changes (`git commit -m 'Add some new-feature'`)
 4. Push to the branch (`git push origin feature/new-feature`)
 5. Open a Pull Request
+
+If you want to add a new theme, please add it to the `themes/` directory.
+
+If you want to add a new plugin, please add it to the `plugins/` directory or you can use your own repo to host it.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -475,10 +475,21 @@ LLA includes a powerful theming system that allows you to customize the appearan
 
 **Built-in Themes:**
 
-- **default**: Traditional terminal colors
-- **dark**: Modern dark theme optimized for dark terminals
-- **light**: Clean theme optimized for light terminals
-- **poimandres**: Theme inspired by the Poimandres color scheme
+- **default**: Traditional terminal colors with carefully selected colors for optimal visibility
+- **dark**: Modern dark theme with enhanced visibility and rich colors for dark terminals
+- **light**: Clean theme optimized for light terminals with maximum readability
+- **ayu_dark**: Dark theme inspired by the Ayu Dark color scheme, featuring deep backgrounds and vibrant accents
+- **ayu_light**: Light theme with carefully selected colors for optimal readability
+- **ayu_mirage**: Refined dark theme with muted colors and soft contrasts
+- **catppuccin_mocha**: A soothing pastel theme for the high-spirited, featuring warm, cozy colors
+- **dracula**: Classic Dracula color scheme with vibrant colors and high contrast
+- **gruvbox_dark**: Retro groove color scheme with warm, earthy tones and high contrast
+- **material_ocean**: Deep blue theme based on Material Design, featuring oceanic colors
+- **nord**: Arctic, north-bluish color palette with elegant pastel colors
+- **one_dark**: Dark theme inspired by Atom, featuring a perfect balance of cool and warm colors
+- **poimandres**: Deep space aesthetic with vibrant accents
+- **tokyo_night**: Dark theme inspired by the vibrant lights of Tokyo at night
+- **vesper**: Minimalist dark theme with warm accents
 
 **Using Themes:**
 

--- a/lla/Cargo.toml
+++ b/lla/Cargo.toml
@@ -27,7 +27,7 @@ walkdir.workspace = true
 tempfile.workspace = true
 users.workspace = true
 parking_lot.workspace = true
-lla_plugin_interface = { version = "0.3.4", path = "../lla_plugin_interface" }
+lla_plugin_interface = { version = "0.3.5", path = "../lla_plugin_interface" }
 once_cell.workspace = true
 dashmap.workspace = true
 unicode-width.workspace = true

--- a/lla/src/commands/args.rs
+++ b/lla/src/commands/args.rs
@@ -13,6 +13,7 @@ pub struct Args {
     pub timeline_format: bool,
     pub git_format: bool,
     pub show_icons: bool,
+    pub no_color: bool,
     pub sort_by: String,
     pub sort_reverse: bool,
     pub sort_dirs_first: bool,
@@ -73,6 +74,7 @@ impl Args {
                     timeline_format: config.default_format == "timeline",
                     git_format: config.default_format == "git",
                     show_icons: config.show_icons,
+                    no_color: false,
                     sort_by: config.default_sort.clone(),
                     sort_reverse: false,
                     sort_dirs_first: config.sort.dirs_first,
@@ -158,6 +160,11 @@ impl Args {
                 Arg::with_name("no-icons")
                     .long("no-icons")
                     .help("Hide icons for files and directories (overrides config setting)"),
+            )
+            .arg(
+                Arg::with_name("no-color")
+                    .long("no-color")
+                    .help("Disable all colors in the output"),
             )
             .arg(
                 Arg::with_name("sort")
@@ -418,6 +425,7 @@ impl Args {
             git_format: matches.is_present("git") || config.default_format == "git",
             show_icons: matches.is_present("icons")
                 || (!matches.is_present("no-icons") && config.show_icons),
+            no_color: matches.is_present("no-color"),
             sort_by: matches
                 .value_of("sort")
                 .unwrap_or(&config.default_sort)

--- a/lla/src/config/default.toml
+++ b/lla/src/config/default.toml
@@ -1,0 +1,155 @@
+# lla default theme
+name = "default"
+author = "Mohamed Achaq"
+description = "A modern, high-contrast theme for lla with carefully selected colors for optimal visibility"
+
+[colors]
+# Core UI Elements
+file = { r = 220, g = 220, b = 220 }      # Light Gray - Better than pure white for eye comfort
+directory = { r = 74, g = 144, b = 226 }  # Vibrant Blue - More saturated and visible
+symlink = { r = 42, g = 161, b = 152 }    # Teal - Distinct from directory
+executable = { r = 126, g = 211, b = 33 } # Lime Green - More visible than traditional green
+
+# Metadata
+size = { r = 42, g = 161, b = 152 }   # Teal - Softer than pure green
+date = { r = 170, g = 170, b = 170 }  # Medium Gray - Subtle but readable
+user = { r = 108, g = 113, b = 196 }  # Soft Purple - Distinct from other elements
+group = { r = 146, g = 146, b = 146 } # Darker Gray - Subtle but visible
+
+# Permissions
+permission_dir = { r = 74, g = 144, b = 226 }   # Vibrant Blue - Matches directory
+permission_read = { r = 42, g = 161, b = 152 }  # Teal - Clear and visible
+permission_write = { r = 203, g = 75, b = 22 }  # Orange - Warning color
+permission_exec = { r = 126, g = 211, b = 33 }  # Lime Green - Matches executable
+permission_none = { r = 146, g = 146, b = 146 } # Darker Gray - Clearly shows lack of permission
+
+[special_files]
+# Special Folders
+[special_files.folders]
+# Development folders
+"node_modules" = { r = 146, g = 146, b = 146 } # Darker Gray
+"target" = { r = 146, g = 146, b = 146 }       # Darker Gray
+"dist" = { r = 146, g = 146, b = 146 }         # Darker Gray
+".git" = { r = 203, g = 75, b = 22 }           # Orange - More visible than red
+"build" = { r = 146, g = 146, b = 146 }        # Darker Gray
+".cache" = { r = 146, g = 146, b = 146 }       # Darker Gray
+
+# Environment folders
+"*-env" = { r = 126, g = 211, b = 33 } # Lime Green
+"venv" = { r = 126, g = 211, b = 33 }  # Lime Green
+".env" = { r = 126, g = 211, b = 33 }  # Lime Green
+
+# Pattern matches for folders
+"*.d" = { r = 74, g = 144, b = 226 }      # Vibrant Blue
+"*_cache" = { r = 146, g = 146, b = 146 } # Darker Gray
+"*-cache" = { r = 146, g = 146, b = 146 } # Darker Gray
+
+# Dotfiles
+[special_files.dotfiles]
+".gitignore" = { r = 42, g = 161, b = 152 }    # Teal
+".env" = { r = 203, g = 75, b = 22 }           # Orange - Important files
+".dockerignore" = { r = 42, g = 161, b = 152 } # Teal
+".editorconfig" = { r = 42, g = 161, b = 152 } # Teal
+".prettierrc" = { r = 42, g = 161, b = 152 }   # Teal
+".eslintrc" = { r = 42, g = 161, b = 152 }     # Teal
+".babelrc" = { r = 42, g = 161, b = 152 }      # Teal
+
+# Exact matches
+[special_files.exact_match]
+"Dockerfile" = { r = 42, g = 161, b = 152 }         # Teal
+"docker-compose.yml" = { r = 42, g = 161, b = 152 } # Teal
+"Makefile" = { r = 211, g = 54, b = 130 }           # Deep Pink - Important build files
+"CMakeLists.txt" = { r = 211, g = 54, b = 130 }     # Deep Pink
+"README.md" = { r = 255, g = 199, b = 6 }           # Gold - Important documentation
+"LICENSE" = { r = 255, g = 199, b = 6 }             # Gold
+"package.json" = { r = 203, g = 75, b = 22 }        # Orange
+"Cargo.toml" = { r = 203, g = 75, b = 22 }          # Orange
+"go.mod" = { r = 42, g = 161, b = 152 }             # Teal
+"flake.nix" = { r = 108, g = 113, b = 196 }         # Soft Purple
+"flake.lock" = { r = 146, g = 146, b = 146 }        # Darker Gray
+"shell.nix" = { r = 108, g = 113, b = 196 }         # Soft Purple
+"default.nix" = { r = 108, g = 113, b = 196 }       # Soft Purple
+
+# Pattern matches
+[special_files.patterns]
+"*rc" = { r = 42, g = 161, b = 152 }        # Teal
+"*.min.*" = { r = 146, g = 146, b = 146 }   # Darker Gray
+"*.test.*" = { r = 126, g = 211, b = 33 }   # Lime Green
+"*.spec.*" = { r = 126, g = 211, b = 33 }   # Lime Green
+"*.lock" = { r = 146, g = 146, b = 146 }    # Darker Gray
+"*.config.*" = { r = 42, g = 161, b = 152 } # Teal
+
+[extensions.groups]
+# Development files
+rust = ["rs", "toml", "lock"]
+script = ["js", "mjs", "cjs", "jsx", "json", "json5", "yaml", "yml"]
+typescript = ["ts", "tsx", "d.ts"]
+markup = ["html", "htm", "xml", "vue", "ejs"]
+style = ["css", "scss", "sass", "less", "conf", "config", "ini", "env"]
+executable = [
+    "py",
+    "pyi",
+    "pyw",
+    "sh",
+    "bash",
+    "zsh",
+    "fish",
+    "bat",
+    "cmd",
+    "ps1",
+]
+doc = ["md", "rst", "txt", "doc", "docx", "pdf", "org", "wiki"]
+media = [
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "svg",
+    "bmp",
+    "ico",
+    "webp",
+    "tiff",
+    "mp4",
+    "mov",
+    "avi",
+    "mkv",
+    "flv",
+    "wmv",
+    "webm",
+    "m4v",
+    "3gp",
+]
+archive = ["zip", "tar", "gz", "rar", "7z", "iso", "dmg", "exe", "dll"]
+data = ["csv", "tsv", "sqlite", "db"]
+
+[extensions.colors]
+# Development
+rust = { r = 211, g = 54, b = 130 }       # Deep Pink
+script = { r = 255, g = 199, b = 6 }      # Gold
+typescript = { r = 74, g = 144, b = 226 } # Vibrant Blue
+markup = { r = 108, g = 113, b = 196 }    # Soft Purple
+style = { r = 42, g = 161, b = 152 }      # Teal
+executable = { r = 126, g = 211, b = 33 } # Lime Green
+doc = { r = 220, g = 220, b = 220 }       # Light Gray
+media = { r = 211, g = 54, b = 130 }      # Deep Pink
+archive = { r = 203, g = 75, b = 22 }     # Orange
+data = { r = 255, g = 199, b = 6 }        # Gold
+
+# Individual extension overrides
+rs = { r = 211, g = 54, b = 130 }    # Deep Pink
+toml = { r = 211, g = 54, b = 130 }  # Deep Pink
+lock = { r = 146, g = 146, b = 146 } # Darker Gray
+js = { r = 255, g = 199, b = 6 }     # Gold
+json = { r = 255, g = 199, b = 6 }   # Gold
+yaml = { r = 255, g = 199, b = 6 }   # Gold
+yml = { r = 255, g = 199, b = 6 }    # Gold
+ts = { r = 74, g = 144, b = 226 }    # Vibrant Blue
+tsx = { r = 74, g = 144, b = 226 }   # Vibrant Blue
+html = { r = 108, g = 113, b = 196 } # Soft Purple
+xml = { r = 108, g = 113, b = 196 }  # Soft Purple
+css = { r = 42, g = 161, b = 152 }   # Teal
+scss = { r = 42, g = 161, b = 152 }  # Teal
+py = { r = 126, g = 211, b = 33 }    # Lime Green
+sh = { r = 126, g = 211, b = 33 }    # Lime Green
+md = { r = 220, g = 220, b = 220 }   # Light Gray
+txt = { r = 220, g = 220, b = 220 }  # Light Gray

--- a/lla/src/formatter/table.rs
+++ b/lla/src/formatter/table.rs
@@ -1,7 +1,8 @@
 use super::FileFormatter;
 use crate::error::Result;
 use crate::plugin::PluginManager;
-use crate::utils::color::*;
+use crate::theme::{self, ColorValue};
+use crate::utils::color::{self, *};
 use crate::utils::icons::format_with_icon;
 use colored::*;
 use lla_plugin_interface::proto::DecoratedEntry;
@@ -63,7 +64,17 @@ impl TableFormatter {
         widths
     }
 
+    fn get_border_color() -> Color {
+        theme::color_value_to_color(&ColorValue::Named("bright black".to_string()))
+    }
+
+    fn get_header_color() -> Color {
+        let theme = color::get_theme();
+        theme::color_value_to_color(&theme.colors.directory)
+    }
+
     fn create_separator(widths: &[usize]) -> String {
+        let border_color = Self::get_border_color();
         let mut separator = String::new();
         separator.push('├');
         for (i, &width) in widths.iter().enumerate() {
@@ -73,10 +84,12 @@ impl TableFormatter {
             }
         }
         separator.push('┤');
-        separator.bright_black().to_string()
+        separator.color(border_color).to_string()
     }
 
     fn create_header(widths: &[usize]) -> String {
+        let border_color = Self::get_border_color();
+        let header_color = Self::get_header_color();
         let headers = ["Permissions", "Size", "Modified", "Name"];
         let mut header = String::new();
         header.push('│');
@@ -85,16 +98,18 @@ impl TableFormatter {
             header.push(' ');
             header.push_str(
                 &format!("{:width$}", title, width = width)
+                    .color(header_color)
                     .bold()
                     .to_string(),
             );
             header.push(' ');
             header.push('│');
         }
-        header.bright_black().to_string()
+        header.color(border_color).to_string()
     }
 
     fn create_top_border(widths: &[usize]) -> String {
+        let border_color = Self::get_border_color();
         let mut border = String::new();
         border.push('┌');
         for (i, &width) in widths.iter().enumerate() {
@@ -104,10 +119,11 @@ impl TableFormatter {
             }
         }
         border.push('┐');
-        border.bright_black().to_string()
+        border.color(border_color).to_string()
     }
 
     fn create_bottom_border(widths: &[usize]) -> String {
+        let border_color = Self::get_border_color();
         let mut border = String::new();
         border.push('└');
         for (i, &width) in widths.iter().enumerate() {
@@ -117,7 +133,7 @@ impl TableFormatter {
             }
         }
         border.push('┘');
-        border.bright_black().to_string()
+        border.color(border_color).to_string()
     }
 
     fn format_cell(content: &str, width: usize, align_right: bool) -> String {

--- a/lla/src/formatter/timeline.rs
+++ b/lla/src/formatter/timeline.rs
@@ -1,7 +1,8 @@
 use super::FileFormatter;
 use crate::error::Result;
 use crate::plugin::PluginManager;
-use crate::utils::color::{colorize_file_name, colorize_file_name_with_icon};
+use crate::theme::{self, ColorValue};
+use crate::utils::color::{self, colorize_file_name, colorize_file_name_with_icon};
 use crate::utils::icons::format_with_icon;
 use chrono::{DateTime, Duration, Local};
 use colored::*;
@@ -38,6 +39,25 @@ impl TimelineFormatter {
         } else {
             dt.format("%b %d, %Y").to_string()
         }
+    }
+
+    fn get_header_color() -> Color {
+        let theme = color::get_theme();
+        theme::color_value_to_color(&theme.colors.directory)
+    }
+
+    fn get_separator_color() -> Color {
+        theme::color_value_to_color(&ColorValue::Named("bright black".to_string()))
+    }
+
+    fn get_time_color() -> Color {
+        let theme = color::get_theme();
+        theme::color_value_to_color(&theme.colors.date)
+    }
+
+    fn get_commit_color() -> Color {
+        let theme = color::get_theme();
+        theme::color_value_to_color(&theme.colors.symlink)
     }
 }
 
@@ -110,8 +130,8 @@ impl FileFormatter for TimelineFormatter {
         for (group, entries) in groups {
             output.push_str(&format!(
                 "\n{}\n{}\n",
-                group.display_name().bright_blue().bold(),
-                "─".repeat(40).bright_black()
+                group.display_name().color(Self::get_header_color()).bold(),
+                "─".repeat(40).color(Self::get_separator_color())
             ));
 
             for entry in entries {
@@ -119,7 +139,7 @@ impl FileFormatter for TimelineFormatter {
                 let modified = UNIX_EPOCH + std::time::Duration::from_secs(modified);
                 let dt = DateTime::<Local>::from(modified);
 
-                let time_str = Self::format_relative_time(dt).bright_black();
+                let time_str = Self::format_relative_time(dt).color(Self::get_time_color());
 
                 let path = Path::new(&entry.path);
                 let colored_name = colorize_file_name(path).to_string();
@@ -134,7 +154,7 @@ impl FileFormatter for TimelineFormatter {
                     .split_whitespace()
                     .find(|s| s.contains("commit:"))
                 {
-                    format!(" {}", git_field.bright_yellow())
+                    format!(" {}", git_field.color(Self::get_commit_color()))
                 } else {
                     String::new()
                 };

--- a/lla/src/formatter/tree.rs
+++ b/lla/src/formatter/tree.rs
@@ -1,6 +1,7 @@
 use super::FileFormatter;
 use crate::error::Result;
 use crate::plugin::PluginManager;
+use crate::theme::{self, ColorValue};
 use crate::utils::color::{colorize_file_name, colorize_file_name_with_icon};
 use crate::utils::icons::format_with_icon;
 use colored::*;
@@ -25,7 +26,8 @@ impl TreePart {
     }
 
     fn colored(self) -> ColoredString {
-        self.as_str().bright_black()
+        let color = theme::color_value_to_color(&ColorValue::Named("bright black".to_string()));
+        self.as_str().color(color)
     }
 }
 

--- a/lla/src/main.rs
+++ b/lla/src/main.rs
@@ -7,6 +7,7 @@ mod installer;
 mod lister;
 mod plugin;
 mod sorter;
+mod theme;
 mod utils;
 
 use commands::args::{Args, Command};
@@ -14,10 +15,15 @@ use commands::command_handler::handle_command;
 use config::Config;
 use error::Result;
 use plugin::PluginManager;
+use utils::color::set_theme;
 
 fn main() -> Result<()> {
     let (mut config, config_error) = load_config()?;
+
+    set_theme(config.get_theme());
+
     let args = Args::parse(&config);
+    theme::set_no_color(args.no_color);
 
     if let Some(Command::Clean) = args.command {
         println!("🔄 Starting plugin cleaning...");

--- a/lla/src/theme/mod.rs
+++ b/lla/src/theme/mod.rs
@@ -1,0 +1,427 @@
+use colored::Color;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static NO_COLOR: AtomicBool = AtomicBool::new(false);
+
+pub fn set_no_color(value: bool) {
+    NO_COLOR.store(value, Ordering::SeqCst);
+}
+
+pub fn is_no_color() -> bool {
+    NO_COLOR.load(Ordering::SeqCst)
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ColorValue {
+    Named(String),
+    RGB { r: u8, g: u8, b: u8 },
+    RGBA { r: u8, g: u8, b: u8, a: f32 },
+    HSL { h: f32, s: f32, l: f32 },
+    Hex(String),
+    None,
+}
+
+impl Default for ColorValue {
+    fn default() -> Self {
+        ColorValue::Named("white".to_string())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Theme {
+    pub name: String,
+    pub author: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub colors: ThemeColors,
+    #[serde(default)]
+    pub extensions: ExtensionColors,
+    #[serde(default)]
+    pub special_files: SpecialFiles,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct SpecialFiles {
+    #[serde(default)]
+    pub dotfiles: HashMap<String, ColorValue>,
+    #[serde(default)]
+    pub exact_match: HashMap<String, ColorValue>,
+    #[serde(default)]
+    pub patterns: HashMap<String, ColorValue>,
+    #[serde(default)]
+    pub folders: HashMap<String, ColorValue>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ExtensionColors {
+    #[serde(default)]
+    pub groups: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub colors: HashMap<String, ColorValue>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ThemeColors {
+    #[serde(default = "default_file_color")]
+    pub file: ColorValue,
+    #[serde(default = "default_directory_color")]
+    pub directory: ColorValue,
+    #[serde(default = "default_symlink_color")]
+    pub symlink: ColorValue,
+    #[serde(default = "default_executable_color")]
+    pub executable: ColorValue,
+    #[serde(default = "default_size_color")]
+    pub size: ColorValue,
+    #[serde(default = "default_date_color")]
+    pub date: ColorValue,
+    #[serde(default = "default_user_color")]
+    pub user: ColorValue,
+    #[serde(default = "default_group_color")]
+    pub group: ColorValue,
+    #[serde(default = "default_permission_dir_color")]
+    pub permission_dir: ColorValue,
+    #[serde(default = "default_permission_read_color")]
+    pub permission_read: ColorValue,
+    #[serde(default = "default_permission_write_color")]
+    pub permission_write: ColorValue,
+    #[serde(default = "default_permission_exec_color")]
+    pub permission_exec: ColorValue,
+    #[serde(default = "default_permission_none_color")]
+    pub permission_none: ColorValue,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            name: "default".to_string(),
+            author: None,
+            description: None,
+            colors: ThemeColors::default(),
+            extensions: ExtensionColors::default(),
+            special_files: SpecialFiles::default(),
+        }
+    }
+}
+
+impl Default for ThemeColors {
+    fn default() -> Self {
+        Self {
+            file: default_file_color(),
+            directory: default_directory_color(),
+            symlink: default_symlink_color(),
+            executable: default_executable_color(),
+            size: default_size_color(),
+            date: default_date_color(),
+            user: default_user_color(),
+            group: default_group_color(),
+            permission_dir: default_permission_dir_color(),
+            permission_read: default_permission_read_color(),
+            permission_write: default_permission_write_color(),
+            permission_exec: default_permission_exec_color(),
+            permission_none: default_permission_none_color(),
+        }
+    }
+}
+
+fn default_file_color() -> ColorValue {
+    ColorValue::Named("white".to_string())
+}
+fn default_directory_color() -> ColorValue {
+    ColorValue::Named("bright_blue".to_string())
+}
+fn default_symlink_color() -> ColorValue {
+    ColorValue::Named("bright_cyan".to_string())
+}
+fn default_executable_color() -> ColorValue {
+    ColorValue::Named("bright_green".to_string())
+}
+fn default_size_color() -> ColorValue {
+    ColorValue::Named("green".to_string())
+}
+fn default_date_color() -> ColorValue {
+    ColorValue::Named("bright_blue".to_string())
+}
+fn default_user_color() -> ColorValue {
+    ColorValue::Named("cyan".to_string())
+}
+fn default_group_color() -> ColorValue {
+    ColorValue::Named("bright_black".to_string())
+}
+fn default_permission_dir_color() -> ColorValue {
+    ColorValue::Named("bright_blue".to_string())
+}
+fn default_permission_read_color() -> ColorValue {
+    ColorValue::Named("bright_cyan".to_string())
+}
+fn default_permission_write_color() -> ColorValue {
+    ColorValue::Named("bright_yellow".to_string())
+}
+fn default_permission_exec_color() -> ColorValue {
+    ColorValue::Named("bright_red".to_string())
+}
+fn default_permission_none_color() -> ColorValue {
+    ColorValue::Named("bright_black".to_string())
+}
+
+pub fn color_value_to_color(color_value: &ColorValue) -> Color {
+    if is_no_color() {
+        return Color::White;
+    }
+
+    match color_value {
+        ColorValue::None => Color::White,
+        ColorValue::Named(name) => str_to_color(name),
+        ColorValue::RGB { r, g, b } => Color::TrueColor {
+            r: *r,
+            g: *g,
+            b: *b,
+        },
+        ColorValue::RGBA { r, g, b, a: _ } => Color::TrueColor {
+            r: *r,
+            g: *g,
+            b: *b,
+        },
+        ColorValue::HSL { h, s, l } => {
+            let rgb = hsl_to_rgb(*h, *s, *l);
+            Color::TrueColor {
+                r: rgb.0,
+                g: rgb.1,
+                b: rgb.2,
+            }
+        }
+        ColorValue::Hex(hex) => hex_to_color(hex),
+    }
+}
+
+fn hex_to_color(hex: &str) -> Color {
+    if let Some((r, g, b)) = parse_hex_color(hex) {
+        Color::TrueColor { r, g, b }
+    } else {
+        Color::White
+    }
+}
+
+fn parse_hex_color(hex: &str) -> Option<(u8, u8, u8)> {
+    let hex = hex.trim_start_matches('#');
+
+    match hex.len() {
+        3 => {
+            // Convert 3-digit hex to 6-digit (#RGB -> #RRGGBB)
+            let r = u8::from_str_radix(&hex[0..1].repeat(2), 16).ok()?;
+            let g = u8::from_str_radix(&hex[1..2].repeat(2), 16).ok()?;
+            let b = u8::from_str_radix(&hex[2..3].repeat(2), 16).ok()?;
+            Some((r, g, b))
+        }
+        6 => {
+            // Standard 6-digit hex
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            Some((r, g, b))
+        }
+        8 => {
+            // 8-digit hex with alpha (ignore alpha)
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            Some((r, g, b))
+        }
+        _ => None,
+    }
+}
+
+fn hsl_to_rgb(h: f32, s: f32, l: f32) -> (u8, u8, u8) {
+    let h = h % 360.0;
+    let s = s.clamp(0.0, 1.0);
+    let l = l.clamp(0.0, 1.0);
+
+    if s == 0.0 {
+        let v = (l * 255.0) as u8;
+        return (v, v, v);
+    }
+
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
+    let m = l - c / 2.0;
+
+    let (r, g, b) = match h as u32 {
+        0..=59 => (c, x, 0.0),
+        60..=119 => (x, c, 0.0),
+        120..=179 => (0.0, c, x),
+        180..=239 => (0.0, x, c),
+        240..=299 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+
+    (
+        ((r + m) * 255.0).round() as u8,
+        ((g + m) * 255.0).round() as u8,
+        ((b + m) * 255.0).round() as u8,
+    )
+}
+
+pub fn str_to_color(color_str: &str) -> Color {
+    if color_str.starts_with('#') {
+        if let Some((r, g, b)) = parse_hex_color(color_str) {
+            return Color::TrueColor { r, g, b };
+        }
+    }
+
+    match color_str.to_lowercase().as_str() {
+        "black" => Color::Black,
+        "red" => Color::Red,
+        "green" => Color::Green,
+        "yellow" => Color::Yellow,
+        "blue" => Color::Blue,
+        "magenta" => Color::Magenta,
+        "cyan" => Color::Cyan,
+        "white" => Color::White,
+        "bright_black" | "gray" | "grey" => Color::BrightBlack,
+        "bright_red" => Color::BrightRed,
+        "bright_green" => Color::BrightGreen,
+        "bright_yellow" => Color::BrightYellow,
+        "bright_blue" => Color::BrightBlue,
+        "bright_magenta" => Color::BrightMagenta,
+        "bright_cyan" => Color::BrightCyan,
+        "bright_white" => Color::BrightWhite,
+        "navy" => Color::TrueColor { r: 0, g: 0, b: 128 },
+        "teal" => Color::TrueColor {
+            r: 0,
+            g: 128,
+            b: 128,
+        },
+        "maroon" => Color::TrueColor { r: 128, g: 0, b: 0 },
+        "purple" => Color::TrueColor {
+            r: 128,
+            g: 0,
+            b: 128,
+        },
+        "olive" => Color::TrueColor {
+            r: 128,
+            g: 128,
+            b: 0,
+        },
+        "silver" => Color::TrueColor {
+            r: 192,
+            g: 192,
+            b: 192,
+        },
+        _ => Color::White,
+    }
+}
+
+pub fn load_theme(name: &str) -> Option<Theme> {
+    if name == "none" {
+        set_no_color(true);
+        return Some(Theme::default());
+    }
+
+    let config_dir = dirs::home_dir()?.join(".config").join("lla").join("themes");
+    let theme_file = config_dir.join(format!("{}.toml", name));
+
+    if theme_file.exists() {
+        fs::read_to_string(&theme_file)
+            .ok()
+            .and_then(|content| toml::from_str(&content).ok())
+    } else {
+        None
+    }
+}
+
+pub fn list_themes() -> std::io::Result<Vec<String>> {
+    let mut themes = vec!["default".to_string(), "none".to_string()];
+
+    let config_dir = dirs::home_dir()
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "Home directory not found")
+        })?
+        .join(".config")
+        .join("lla")
+        .join("themes");
+
+    if config_dir.exists() {
+        for entry in fs::read_dir(config_dir)? {
+            let entry = entry?;
+            if entry.path().extension().and_then(|s| s.to_str()) == Some("toml") {
+                if let Some(name) = entry.path().file_stem().and_then(|s| s.to_str()) {
+                    if name != "default" && name != "none" {
+                        themes.push(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(themes)
+}
+
+pub fn get_file_color(path: &std::path::Path) -> Option<Color> {
+    let theme = get_theme()?;
+    let filename = path.file_name()?.to_str()?;
+
+    if path.is_dir() {
+        if let Some(color) = theme.special_files.folders.get(filename) {
+            return Some(color_value_to_color(color));
+        }
+        for (pattern, color) in &theme.special_files.folders {
+            if pattern_matches(pattern, filename) {
+                return Some(color_value_to_color(color));
+            }
+        }
+        return Some(color_value_to_color(&theme.colors.directory));
+    }
+
+    if let Some(color) = theme.special_files.exact_match.get(filename) {
+        return Some(color_value_to_color(color));
+    }
+
+    if filename.starts_with('.') {
+        if let Some(color) = theme.special_files.dotfiles.get(filename) {
+            return Some(color_value_to_color(color));
+        }
+    }
+
+    for (pattern, color) in &theme.special_files.patterns {
+        if pattern_matches(pattern, filename) {
+            return Some(color_value_to_color(color));
+        }
+    }
+
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        let ext = ext.to_lowercase();
+        if let Some(color) = theme.extensions.colors.get(&ext) {
+            return Some(color_value_to_color(color));
+        }
+
+        for (group_name, _) in &theme.extensions.groups {
+            if let Some(extensions) = theme.extensions.groups.get(group_name) {
+                if extensions.iter().any(|e| e.to_lowercase() == ext) {
+                    if let Some(color) = theme.extensions.colors.get(group_name) {
+                        return Some(color_value_to_color(color));
+                    }
+                }
+            }
+        }
+    }
+
+    Some(color_value_to_color(&theme.colors.file))
+}
+
+fn pattern_matches(pattern: &str, filename: &str) -> bool {
+    if pattern.starts_with('*') {
+        filename.ends_with(&pattern[1..])
+    } else if pattern.ends_with('*') {
+        filename.starts_with(&pattern[..pattern.len() - 1])
+    } else {
+        filename == pattern
+    }
+}
+
+fn get_theme() -> Option<&'static Theme> {
+    use crate::utils::color::get_theme;
+    Some(get_theme())
+}

--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -1,50 +1,21 @@
+use crate::commands::args::Args;
+use crate::theme::{color_value_to_color, get_file_color, is_no_color, ColorValue, Theme};
 use colored::*;
 use std::path::Path;
+use std::sync::OnceLock;
 
-pub const FILE_COLOR: Color = Color::White;
-pub const DIRECTORY_COLOR: Color = Color::BrightBlue;
-pub const SYMLINK_COLOR: Color = Color::BrightCyan;
-pub const EXECUTABLE_COLOR: Color = Color::BrightGreen;
-pub const SIZE_COLOR: Color = Color::Green;
-pub const DATE_COLOR: Color = Color::BrightBlue;
-pub const USER_COLOR: Color = Color::Cyan;
-pub const GROUP_COLOR: Color = Color::BrightBlack;
+static CURRENT_THEME: OnceLock<Theme> = OnceLock::new();
 
-pub const PERMISSION_DIR_COLOR: Color = Color::BrightBlue;
-pub const PERMISSION_READ_COLOR: Color = Color::BrightCyan;
-pub const PERMISSION_WRITE_COLOR: Color = Color::BrightYellow;
-pub const PERMISSION_EXEC_COLOR: Color = Color::BrightRed;
-pub const PERMISSION_NONE_COLOR: Color = Color::BrightBlack;
+pub fn set_theme(theme: Theme) {
+    let _ = CURRENT_THEME.set(theme);
+}
 
-pub const RUST_COLOR: Color = Color::Red;
-pub const SCRIPT_COLOR: Color = Color::Yellow;
-pub const TYPESCRIPT_COLOR: Color = Color::Blue;
-pub const MARKUP_COLOR: Color = Color::Magenta;
-pub const STYLE_COLOR: Color = Color::Cyan;
-pub const DOC_COLOR: Color = Color::White;
-pub const MEDIA_COLOR: Color = Color::Magenta;
-pub const ARCHIVE_COLOR: Color = Color::Red;
-pub const DATA_COLOR: Color = Color::Yellow;
+pub fn get_theme() -> &'static Theme {
+    CURRENT_THEME.get_or_init(Theme::default)
+}
 
-fn get_extension_color(path: &Path) -> Option<Color> {
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| match ext.to_lowercase().as_str() {
-            "rs" | "toml" | "lock" => RUST_COLOR,
-            "js" | "mjs" | "cjs" | "jsx" | "json" | "json5" | "yaml" | "yml" => SCRIPT_COLOR,
-            "ts" | "tsx" | "d.ts" => TYPESCRIPT_COLOR,
-            "html" | "htm" | "xml" | "vue" | "ejs" => MARKUP_COLOR,
-            "css" | "scss" | "sass" | "less" | "conf" | "config" | "ini" | "env" => STYLE_COLOR,
-            "py" | "pyi" | "pyw" | "sh" | "bash" | "zsh" | "fish" | "bat" | "cmd" | "ps1" => {
-                EXECUTABLE_COLOR
-            }
-            "md" | "rst" | "txt" | "doc" | "docx" | "pdf" | "org" | "wiki" => DOC_COLOR,
-            "png" | "jpg" | "jpeg" | "gif" | "svg" | "bmp" | "ico" | "webp" | "tiff" | "mp4"
-            | "mov" | "avi" | "mkv" | "flv" | "wmv" | "webm" | "m4v" | "3gp" => MEDIA_COLOR,
-            "zip" | "tar" | "gz" | "rar" | "7z" | "iso" | "dmg" | "exe" | "dll" => ARCHIVE_COLOR,
-            "csv" | "tsv" | "sqlite" | "db" => DATA_COLOR,
-            _ => FILE_COLOR,
-        })
+fn get_color(color_value: &ColorValue) -> Color {
+    color_value_to_color(color_value)
 }
 
 pub fn colorize_file_name(path: &Path) -> ColoredString {
@@ -53,62 +24,117 @@ pub fn colorize_file_name(path: &Path) -> ColoredString {
         .and_then(|n| n.to_str())
         .unwrap_or_else(|| path.to_str().unwrap_or(""));
 
+    if is_no_color() {
+        return if path.is_dir() {
+            format!("{}/", name).normal()
+        } else {
+            name.normal()
+        };
+    }
+
+    let theme = get_theme();
+
     if path.is_dir() {
-        format!("{}/", name).color(DIRECTORY_COLOR).bold()
+        if let Some(color) = get_file_color(path) {
+            format!("{}/", name).color(color).bold()
+        } else {
+            format!("{}", name)
+                .color(get_color(&theme.colors.directory))
+                .bold()
+        }
     } else if path.is_symlink() {
-        name.color(SYMLINK_COLOR).italic().underline()
+        name.color(get_color(&theme.colors.symlink))
+            .italic()
+            .underline()
     } else if is_executable(path) {
-        name.color(EXECUTABLE_COLOR).bold()
+        name.color(get_color(&theme.colors.executable)).bold()
     } else if let Some(color) = get_extension_color(path) {
         name.color(color)
     } else {
-        name.color(FILE_COLOR)
+        name.color(get_color(&theme.colors.file))
     }
 }
 
 pub fn colorize_file_name_with_icon(path: &Path, content: String) -> ColoredString {
     let parts: Vec<&str> = content.split(' ').collect();
     if parts.len() != 2 {
-        return content.color(FILE_COLOR);
+        return if is_no_color() {
+            content.normal()
+        } else {
+            content.color(get_color(&get_theme().colors.file))
+        };
     }
 
     let icon = parts[0];
     let name = parts[1];
 
+    if is_no_color() {
+        return if path.is_dir() {
+            format!("{} {}", icon, name).normal()
+        } else {
+            format!("{} {}", icon, name).normal()
+        };
+    }
+
+    let theme = get_theme();
+
     if path.is_dir() {
-        format!("{} {}", icon, name.normal()).color(DIRECTORY_COLOR)
+        if let Some(color) = get_file_color(path) {
+            format!("{} {}", icon, name).color(color).bold()
+        } else {
+            format!("{} {}", icon, name)
+                .color(get_color(&theme.colors.directory))
+                .bold()
+        }
     } else if path.is_symlink() {
-        format!("{} {}", icon, name.normal())
-            .color(SYMLINK_COLOR)
+        format!("{} {}", icon, name)
+            .color(get_color(&theme.colors.symlink))
             .italic()
             .underline()
     } else if is_executable(path) {
-        format!("{} {}", icon, name.normal()).color(EXECUTABLE_COLOR)
+        format!("{} {}", icon, name)
+            .color(get_color(&theme.colors.executable))
+            .bold()
     } else if let Some(color) = get_extension_color(path) {
-        format!("{} {}", icon, name.normal()).color(color)
+        format!("{} {}", icon, name).color(color)
     } else {
-        format!("{} {}", icon, name.normal()).color(FILE_COLOR)
+        format!("{} {}", icon, name).color(get_color(&theme.colors.file))
     }
 }
 
 pub fn colorize_size(size: u64) -> ColoredString {
-    if size < 1024 {
-        format!("{}B", size).color(SIZE_COLOR)
+    let formatted = if size < 1024 {
+        format!("{}B", size)
     } else if size < 1024 * 1024 {
-        format!("{:.1}K", size as f64 / 1024.0).color(SIZE_COLOR)
+        format!("{:.1}K", size as f64 / 1024.0)
     } else if size < 1024 * 1024 * 1024 {
-        format!("{:.1}M", size as f64 / (1024.0 * 1024.0)).color(SIZE_COLOR)
+        format!("{:.1}M", size as f64 / (1024.0 * 1024.0))
     } else {
-        format!("{:.1}G", size as f64 / (1024.0 * 1024.0 * 1024.0)).color(SIZE_COLOR)
+        format!("{:.1}G", size as f64 / (1024.0 * 1024.0 * 1024.0))
+    };
+
+    if is_no_color() {
+        formatted.normal()
+    } else {
+        let theme = get_theme();
+        formatted.color(get_color(&theme.colors.size))
     }
 }
 
 pub fn colorize_group(group: &str) -> ColoredString {
-    group.color(GROUP_COLOR)
+    if is_no_color() {
+        group.normal()
+    } else {
+        group.color(get_color(&get_theme().colors.group))
+    }
 }
 
 pub fn colorize_user(user: &str) -> ColoredString {
-    user.color(USER_COLOR)
+    if is_no_color() {
+        user.normal()
+    } else {
+        user.color(get_color(&get_theme().colors.user))
+    }
 }
 
 use std::fs::Permissions;
@@ -116,10 +142,17 @@ use std::os::unix::fs::PermissionsExt;
 
 pub fn colorize_permissions(permissions: &Permissions) -> String {
     let mode = permissions.mode();
+
+    if is_no_color() {
+        return format_permissions_no_color(mode);
+    }
+
+    let theme = get_theme();
+
     let file_type = if mode & 0o40000 != 0 {
-        "d".color(PERMISSION_DIR_COLOR)
+        "d".color(get_color(&theme.colors.permission_dir))
     } else {
-        "-".color(PERMISSION_NONE_COLOR)
+        "-".color(get_color(&theme.colors.permission_none))
     };
     let user = triplet(mode, 6);
     let group = triplet(mode, 3);
@@ -127,28 +160,80 @@ pub fn colorize_permissions(permissions: &Permissions) -> String {
     format!("{}{}{}{}", file_type, user, group, other)
 }
 
+fn format_permissions_no_color(mode: u32) -> String {
+    let file_type = if mode & 0o40000u32 != 0u32 { "d" } else { "-" };
+    let read = |shift| {
+        if mode >> shift & 0o4u32 != 0u32 {
+            "r"
+        } else {
+            "-"
+        }
+    };
+    let write = |shift| {
+        if mode >> shift & 0o2u32 != 0u32 {
+            "w"
+        } else {
+            "-"
+        }
+    };
+    let exec = |shift| {
+        if mode >> shift & 0o1u32 != 0u32 {
+            "x"
+        } else {
+            "-"
+        }
+    };
+
+    format!(
+        "{}{}{}{}{}{}{}{}{}{}",
+        file_type,
+        read(6),
+        write(6),
+        exec(6),
+        read(3),
+        write(3),
+        exec(3),
+        read(0),
+        write(0),
+        exec(0)
+    )
+}
+
 fn triplet(mode: u32, shift: u32) -> String {
-    let r = if mode >> (shift + 2) & 1 != 0 {
-        "r".color(PERMISSION_READ_COLOR).to_string()
+    let theme = get_theme();
+    let r = if mode >> (shift + 2) & 1u32 != 0 {
+        "r".color(get_color(&theme.colors.permission_read))
+            .to_string()
     } else {
-        "-".color(PERMISSION_NONE_COLOR).to_string()
+        "-".color(get_color(&theme.colors.permission_none))
+            .to_string()
     };
-    let w = if mode >> (shift + 1) & 1 != 0 {
-        "w".color(PERMISSION_WRITE_COLOR).to_string()
+    let w = if mode >> (shift + 1) & 1u32 != 0 {
+        "w".color(get_color(&theme.colors.permission_write))
+            .to_string()
     } else {
-        "-".color(PERMISSION_NONE_COLOR).to_string()
+        "-".color(get_color(&theme.colors.permission_none))
+            .to_string()
     };
-    let x = if mode >> shift & 1 != 0 {
-        "x".color(PERMISSION_EXEC_COLOR).to_string()
+    let x = if mode >> shift & 1u32 != 0 {
+        "x".color(get_color(&theme.colors.permission_exec))
+            .to_string()
     } else {
-        "-".color(PERMISSION_NONE_COLOR).to_string()
+        "-".color(get_color(&theme.colors.permission_none))
+            .to_string()
     };
     format!("{}{}{}", r, w, x)
 }
 
 pub fn colorize_date(date: &std::time::SystemTime) -> ColoredString {
     let datetime: chrono::DateTime<chrono::Local> = (*date).into();
-    datetime.format("%b %d %H:%M").to_string().color(DATE_COLOR)
+    let formatted = datetime.format("%b %d %H:%M").to_string();
+
+    if is_no_color() {
+        formatted.normal()
+    } else {
+        formatted.color(get_color(&get_theme().colors.date))
+    }
 }
 
 fn is_executable(path: &Path) -> bool {
@@ -159,4 +244,28 @@ fn is_executable(path: &Path) -> bool {
         }
     }
     false
+}
+
+fn get_extension_color(path: &Path) -> Option<Color> {
+    if is_no_color() {
+        return None;
+    }
+    use crate::theme::get_file_color;
+    get_file_color(path)
+}
+
+pub struct ColorState {
+    pub no_color: bool,
+}
+
+impl ColorState {
+    pub fn new(args: &Args) -> Self {
+        Self {
+            no_color: args.no_color,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        !self.no_color
+    }
 }

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,6 +1,6 @@
 # LLA Themes
 
-LLA (Light List Alternative) provides a powerful and flexible theming system that allows you to customize the appearance of your file listings. Each theme is defined in a TOML file and can customize colors for files, folders, permissions, and more.
+LLA provides a powerful and flexible theming system that allows you to customize the appearance of your file listings. Each theme is defined in a TOML file and can customize colors for files, folders, permissions, and more.
 
 ## Table of Contents
 
@@ -212,10 +212,21 @@ When determining a file's color, LLA follows this priority:
 
 LLA includes several pre-configured themes:
 
-- **default**: Traditional terminal colors
-- **dark**: Modern dark theme optimized for dark terminals
-- **light**: Clean theme optimized for light terminals
-- **poimandres**: Theme inspired by the Poimandres color scheme
+- **default**: Traditional terminal colors with carefully selected colors for optimal visibility
+- **dark**: Modern dark theme with enhanced visibility and rich colors for dark terminals
+- **light**: Clean theme optimized for light terminals with maximum readability
+- **ayu_dark**: Dark theme inspired by the Ayu Dark color scheme, featuring deep backgrounds and vibrant accents
+- **ayu_light**: Light theme with carefully selected colors for optimal readability
+- **ayu_mirage**: Refined dark theme with muted colors and soft contrasts
+- **catppuccin_mocha**: A soothing pastel theme for the high-spirited, featuring warm, cozy colors
+- **dracula**: Classic Dracula color scheme with vibrant colors and high contrast
+- **gruvbox_dark**: Retro groove color scheme with warm, earthy tones and high contrast
+- **material_ocean**: Deep blue theme based on Material Design, featuring oceanic colors
+- **nord**: Arctic, north-bluish color palette with elegant pastel colors
+- **one_dark**: Dark theme inspired by Atom, featuring a perfect balance of cool and warm colors
+- **poimandres**: Deep space aesthetic with vibrant accents
+- **tokyo_night**: Dark theme inspired by the vibrant lights of Tokyo at night
+- **vesper**: Minimalist dark theme with warm accents
 
 ## Usage
 

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,0 +1,244 @@
+# LLA Themes
+
+LLA (Light List Alternative) provides a powerful and flexible theming system that allows you to customize the appearance of your file listings. Each theme is defined in a TOML file and can customize colors for files, folders, permissions, and more.
+
+## Table of Contents
+
+- [Theme Location](#theme-location)
+- [Theme Structure](#theme-structure)
+- [Color Formats](#color-formats)
+- [Basic Elements](#basic-elements)
+- [Special Files](#special-files)
+- [Extension System](#extension-system)
+- [Built-in Themes](#built-in-themes)
+- [Usage](#usage)
+
+## Theme Location
+
+Themes are stored in `~/.config/lla/themes/` with a `.toml` extension:
+
+```
+~/.config/lla/themes/
+├── dark.toml
+├── light.toml
+├── poimandres.toml
+└── custom.toml
+```
+
+## Theme Structure
+
+A theme file has the following main sections:
+
+```toml
+# Theme metadata
+name = "my_theme"
+author = "Your Name"
+description = "A description of your theme"
+
+# Core colors for basic elements
+[colors]
+file = "#FFFFFF"
+directory = "#89AFFF"
+...
+
+# Special file rules
+[special_files]
+...
+
+# Extension-based colors
+[extensions]
+...
+```
+
+## Color Formats
+
+LLA supports multiple color formats for maximum flexibility:
+
+```toml
+[colors]
+# 1. Named Colors (Basic terminal colors)
+file = "white"
+directory = "blue"
+symlink = "bright_cyan"
+
+# 2. RGB Format
+file = { r = 255, g = 255, b = 255 }
+directory = { r = 81, g = 154, b = 255 }
+
+# 3. Hex Format
+file = "#FFFFFF"              # 6-digit hex
+directory = "#89F"           # 3-digit hex
+symlink = "#89DBFFFF"       # 8-digit hex (alpha ignored)
+
+# 4. HSL Format (h: 0-360, s: 0-1, l: 0-1)
+directory = { h = 180, s = 0.5, l = 0.6 }
+
+# 5. No Color
+disabled = "none"
+```
+
+### Available Named Colors
+
+Basic Colors:
+
+- `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`
+
+Bright Variants:
+
+- `bright_black` (or `gray`/`grey`)
+- `bright_red`, `bright_green`, `bright_yellow`
+- `bright_blue`, `bright_magenta`, `bright_cyan`, `bright_white`
+
+Additional Colors:
+
+- `navy`, `teal`, `maroon`, `purple`, `olive`, `silver`
+
+## Basic Elements
+
+The `[colors]` section defines the core colors:
+
+```toml
+[colors]
+# Core UI Elements
+file = "#FFFFFF"        # Regular files
+directory = "#89AFFF"   # Directories
+symlink = "#89DBFF"     # Symbolic links
+executable = "#5DE4B3"  # Executable files
+
+# Metadata
+size = "#5DE4B3"       # File sizes
+date = "#FCBCFA"       # Timestamps
+user = "#D0679D"       # User names
+group = "#8A9092"      # Group names
+
+# Permissions
+permission_dir = "#89AFFF"   # Directory permission
+permission_read = "#5DE4B3"  # Read permission
+permission_write = "#FFFFC2" # Write permission
+permission_exec = "#D0679D"  # Execute permission
+permission_none = "#282E30"  # No permission
+```
+
+## Special Files
+
+The `[special_files]` section allows you to define custom colors for specific files and patterns:
+
+### 1. Custom Folders
+
+```toml
+[special_files.folders]
+# Exact folder names
+"node_modules" = "#666666"  # Dim gray for node modules
+"target" = "#444444"        # Dark gray for build outputs
+".git" = "#FF6B6B"          # Red for git directory
+
+# Folder patterns
+"build*" = "#444444"        # Any folder starting with "build"
+"*.cache" = "#666666"       # Any folder ending with ".cache"
+"*-env" = "#5DE4B3"        # Any folder ending with "-env"
+```
+
+### 2. Dotfiles
+
+```toml
+[special_files.dotfiles]
+".gitignore" = "#89DBFF"
+".env" = "#FFFFC2"
+".dockerignore" = "#89DBFF"
+```
+
+### 3. Exact Matches
+
+```toml
+[special_files.exact_match]
+"Dockerfile" = "#89DBFF"
+"Makefile" = "#D0679D"
+"README.md" = "#FFFFC2"
+```
+
+### 4. Pattern Matches
+
+```toml
+[special_files.patterns]
+"*rc" = "#89DBFF"         # Files ending in "rc"
+"*.min.*" = "#282E30"     # Minified files
+"*.test.*" = "#5DE4B3"    # Test files
+```
+
+## Extension System
+
+The extension system provides two ways to define colors for file extensions:
+
+### 1. Extension Groups
+
+Group related extensions together:
+
+```toml
+[extensions.groups]
+# Group multiple extensions
+rust = ["rs", "toml"]
+web = ["html", "css", "js"]
+docs = ["md", "rst", "txt"]
+
+# Define colors for groups
+[extensions.colors]
+rust = "#FF5733"    # All rust-related files
+web = "#61AFEF"     # All web files
+docs = "#98C379"    # All documentation files
+
+# Override specific extensions
+rs = "#FF0000"      # Override just .rs files
+```
+
+## Color Resolution Order
+
+When determining a file's color, LLA follows this priority:
+
+1. If it's a directory:
+
+   - Exact folder name match
+   - Folder pattern match
+   - Default directory color
+
+2. If it's a file:
+   - Exact filename match
+   - Dotfile match
+   - Pattern match
+   - Extension-specific color
+   - Extension group color
+   - Default file color
+
+## Built-in Themes
+
+LLA includes several pre-configured themes:
+
+- **default**: Traditional terminal colors
+- **dark**: Modern dark theme optimized for dark terminals
+- **light**: Clean theme optimized for light terminals
+- **poimandres**: Theme inspired by the Poimandres color scheme
+
+## Usage
+
+Set your theme in `~/.config/lla/config.toml`:
+
+```toml
+theme = "dark"  # Without .toml extension
+```
+
+Or use the command line:
+
+```bash
+lla config --set theme dark
+```
+
+To disable colors:
+
+```bash
+lla config --set theme none
+```
+
+or if you don't want any colors you can add "--no-colors" flag to lla:
+
+```bash
+lla --no-colors # works with all listing commands
+```

--- a/themes/ayu_dark.toml
+++ b/themes/ayu_dark.toml
@@ -1,4 +1,3 @@
-# lla ayu dark theme
 name = "ayu_dark"
 author = "Mohamed Achaq"
 description = "A dark theme inspired by the Ayu Dark color scheme, featuring deep backgrounds and vibrant accents"

--- a/themes/ayu_dark.toml
+++ b/themes/ayu_dark.toml
@@ -1,0 +1,159 @@
+# lla ayu dark theme
+name = "ayu_dark"
+author = "Mohamed Achaq"
+description = "A dark theme inspired by the Ayu Dark color scheme, featuring deep backgrounds and vibrant accents"
+
+[colors]
+file = "#BFBDB6"
+directory = "#E6B450"
+symlink = "#59C2FF"
+executable = "#7FD962"
+
+size = "#565B66"
+date = "#565B66"
+user = "#F07178"
+group = "#636A72"
+
+permission_dir = "#E6B450"
+permission_read = "#7FD962"
+permission_write = "#F07178"
+permission_exec = "#D95757"
+permission_none = "#454B55"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.2 }
+"target" = "#E7EAED"
+"dist" = "#E7EAED"
+".git" = "#E6B450"
+"build" = "#E7EAED"
+".cache" = "#E7EAED"
+"*-env" = "#95E6CB"
+"venv" = "#95E6CB"
+".env" = "#95E6CB"
+"*.d" = "#E6B450"
+"*_cache" = "#E7EAED"
+"*-cache" = "#E7EAED"
+
+[special_files.dotfiles]
+".gitignore" = "#39BAE6"
+".env" = "#E6B450"
+".dockerignore" = "#39BAE6"
+".editorconfig" = "#39BAE6"
+".prettierrc" = "#39BAE6"
+".eslintrc" = "#39BAE6"
+".babelrc" = "#39BAE6"
+
+[special_files.exact_match]
+"Dockerfile" = "#39BAE6"
+"docker-compose.yml" = "#39BAE6"
+"Makefile" = "#FF3333"
+"CMakeLists.txt" = "#FF3333"
+"README.md" = "#E6B450"
+"LICENSE" = "#E6B450"
+"package.json" = "#E6B450"
+"Cargo.toml" = "#FF3333"
+"go.mod" = "#39BAE6"
+"flake.nix" = "#E6B450"
+"flake.lock" = "#E7EAED"
+"shell.nix" = "#E6B450"
+"default.nix" = "#E6B450"
+
+[special_files.patterns]
+"*rc" = "#39BAE6"
+"*.min.*" = "#E7EAED"
+"*.test.*" = "#95E6CB"
+"*.spec.*" = "#95E6CB"
+"*.lock" = "#E7EAED"
+"*.config.*" = "#39BAE6"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF3333"
+python = "#95E6CB"
+javascript = "#E6B450"
+typescript = "#39BAE6"
+java = "#FF3333"
+csharp = "#95E6CB"
+cpp = "#FF3333"
+go = "#39BAE6"
+ruby = "#FF3333"
+php = "#95E6CB"
+swift = "#FF3333"
+kotlin = "#95E6CB"
+nix = "#39BAE6"
+
+markup = "#F07178"
+style = "#95E6CB"
+web_config = "#E6B450"
+
+shell = "#95E6CB"
+script = "#E6B450"
+
+doc = "#B3B1AD"
+
+image = "#FF8F40"
+video = "#FF8F40"
+audio = "#FF8F40"
+
+data = "#E6B450"
+archive = "#FF3333"
+
+rs = "#FF3333"
+py = "#95E6CB"
+js = "#E6B450"
+ts = "#39BAE6"
+jsx = "#E6B450"
+tsx = "#39BAE6"
+vue = "#95E6CB"
+css = "#95E6CB"
+scss = "#95E6CB"
+html = "#F07178"
+md = "#B3B1AD"
+json = "#E6B450"
+yaml = "#E6B450"
+toml = "#E6B450"
+sql = "#39BAE6"

--- a/themes/ayu_light.toml
+++ b/themes/ayu_light.toml
@@ -1,0 +1,159 @@
+# lla ayu light theme
+name = "ayu_light"
+author = "Mohamed Achaq"
+description = "A light theme with carefully selected colors for optimal readability, based on the Ayu Light color scheme"
+
+[colors]
+file = "#5C6166"
+directory = "#FFAA33"
+symlink = "#399EE6"
+executable = "#86B300"
+
+size = "#8A9199"
+date = "#8A9199"
+user = "#F07171"
+group = "#ABADB1"
+
+permission_dir = "#FFAA33"
+permission_read = "#86B300"
+permission_write = "#F07171"
+permission_exec = "#E65050"
+permission_none = "#CCCFD3"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.9 }
+"target" = "#1A1F29"
+"dist" = "#1A1F29"
+".git" = "#FFAA33"
+"build" = "#1A1F29"
+".cache" = "#1A1F29"
+"*-env" = "#86B300"
+"venv" = "#86B300"
+".env" = "#86B300"
+"*.d" = "#399EE6"
+"*_cache" = "#1A1F29"
+"*-cache" = "#1A1F29"
+
+[special_files.dotfiles]
+".gitignore" = "#55B4D4"
+".env" = "#FFAA33"
+".dockerignore" = "#55B4D4"
+".editorconfig" = "#55B4D4"
+".prettierrc" = "#55B4D4"
+".eslintrc" = "#55B4D4"
+".babelrc" = "#55B4D4"
+
+[special_files.exact_match]
+"Dockerfile" = "#55B4D4"
+"docker-compose.yml" = "#55B4D4"
+"Makefile" = "#E65050"
+"CMakeLists.txt" = "#E65050"
+"README.md" = "#FFAA33"
+"LICENSE" = "#FFAA33"
+"package.json" = "#FFAA33"
+"Cargo.toml" = "#E65050"
+"go.mod" = "#55B4D4"
+"flake.nix" = "#FFAA33"
+"flake.lock" = "#1A1F29"
+"shell.nix" = "#FFAA33"
+"default.nix" = "#FFAA33"
+
+[special_files.patterns]
+"*rc" = "#55B4D4"
+"*.min.*" = "#1A1F29"
+"*.test.*" = "#86B300"
+"*.spec.*" = "#86B300"
+"*.lock" = "#1A1F29"
+"*.config.*" = "#55B4D4"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#E65050"
+python = "#4CBF99"
+javascript = "#F2AE49"
+typescript = "#399EE6"
+java = "#E65050"
+csharp = "#4CBF99"
+cpp = "#E65050"
+go = "#399EE6"
+ruby = "#E65050"
+php = "#4CBF99"
+swift = "#E65050"
+kotlin = "#4CBF99"
+nix = "#399EE6"
+
+markup = "#F07171"
+style = "#4CBF99"
+web_config = "#FFAA33"
+
+shell = "#4CBF99"
+script = "#FFAA33"
+
+doc = "#5C6166"
+
+image = "#ED9366"
+video = "#ED9366"
+audio = "#ED9366"
+
+data = "#FFAA33"
+archive = "#E65050"
+
+rs = "#E65050"
+py = "#4CBF99"
+js = "#F2AE49"
+ts = "#399EE6"
+jsx = "#F2AE49"
+tsx = "#399EE6"
+vue = "#4CBF99"
+css = "#4CBF99"
+scss = "#4CBF99"
+html = "#F07171"
+md = "#5C6166"
+json = "#FFAA33"
+yaml = "#FFAA33"
+toml = "#FFAA33"
+sql = "#399EE6"

--- a/themes/ayu_light.toml
+++ b/themes/ayu_light.toml
@@ -1,4 +1,3 @@
-# lla ayu light theme
 name = "ayu_light"
 author = "Mohamed Achaq"
 description = "A light theme with carefully selected colors for optimal readability, based on the Ayu Light color scheme"

--- a/themes/ayu_mirage.toml
+++ b/themes/ayu_mirage.toml
@@ -1,4 +1,3 @@
-# lla ayu mirage theme
 name = "ayu_mirage"
 author = "Mohamed Achaq"
 description = "A refined dark theme with muted colors and soft contrasts, based on the Mirage color scheme"

--- a/themes/ayu_mirage.toml
+++ b/themes/ayu_mirage.toml
@@ -1,0 +1,159 @@
+# lla ayu mirage theme
+name = "ayu_mirage"
+author = "Mohamed Achaq"
+description = "A refined dark theme with muted colors and soft contrasts, based on the Mirage color scheme"
+
+[colors]
+file = "#CCCAC2"
+directory = "#FFCC66"
+symlink = "#73D0FF"
+executable = "#87D96C"
+
+size = "#707A8C"
+date = "#707A8C"
+user = "#F28779"
+group = "#6C7A8B"
+
+permission_dir = "#FFCC66"
+permission_read = "#87D96C"
+permission_write = "#F28779"
+permission_exec = "#FF6666"
+permission_none = "#4A505A"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#E7EAED"
+"dist" = "#E7EAED"
+".git" = "#FFCC66"
+"build" = "#E7EAED"
+".cache" = "#E7EAED"
+"*-env" = "#87D96C"
+"venv" = "#87D96C"
+".env" = "#87D96C"
+"*.d" = "#73D0FF"
+"*_cache" = "#E7EAED"
+"*-cache" = "#E7EAED"
+
+[special_files.dotfiles]
+".gitignore" = "#5CCFE6"
+".env" = "#FFCC66"
+".dockerignore" = "#5CCFE6"
+".editorconfig" = "#5CCFE6"
+".prettierrc" = "#5CCFE6"
+".eslintrc" = "#5CCFE6"
+".babelrc" = "#5CCFE6"
+
+[special_files.exact_match]
+"Dockerfile" = "#5CCFE6"
+"docker-compose.yml" = "#5CCFE6"
+"Makefile" = "#FF6666"
+"CMakeLists.txt" = "#FF6666"
+"README.md" = "#FFCC66"
+"LICENSE" = "#FFCC66"
+"package.json" = "#FFCC66"
+"Cargo.toml" = "#FF6666"
+"go.mod" = "#5CCFE6"
+"flake.nix" = "#FFCC66"
+"flake.lock" = "#E7EAED"
+"shell.nix" = "#FFCC66"
+"default.nix" = "#FFCC66"
+
+[special_files.patterns]
+"*rc" = "#5CCFE6"
+"*.min.*" = "#E7EAED"
+"*.test.*" = "#87D96C"
+"*.spec.*" = "#87D96C"
+"*.lock" = "#E7EAED"
+"*.config.*" = "#5CCFE6"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF6666"
+python = "#95E6CB"
+javascript = "#FFD173"
+typescript = "#73D0FF"
+java = "#FF6666"
+csharp = "#95E6CB"
+cpp = "#FF6666"
+go = "#73D0FF"
+ruby = "#FF6666"
+php = "#95E6CB"
+swift = "#FF6666"
+kotlin = "#95E6CB"
+nix = "#73D0FF"
+
+markup = "#F28779"
+style = "#95E6CB"
+web_config = "#FFCC66"
+
+shell = "#95E6CB"
+script = "#FFCC66"
+
+doc = "#CCCAC2"
+
+image = "#F29E74"
+video = "#F29E74"
+audio = "#F29E74"
+
+data = "#FFCC66"
+archive = "#FF6666"
+
+rs = "#FF6666"
+py = "#95E6CB"
+js = "#FFD173"
+ts = "#73D0FF"
+jsx = "#FFD173"
+tsx = "#73D0FF"
+vue = "#95E6CB"
+css = "#95E6CB"
+scss = "#95E6CB"
+html = "#F28779"
+md = "#CCCAC2"
+json = "#FFCC66"
+yaml = "#FFCC66"
+toml = "#FFCC66"
+sql = "#73D0FF"

--- a/themes/catppuccin_mocha.toml
+++ b/themes/catppuccin_mocha.toml
@@ -17,22 +17,22 @@ permission_dir = "#89B4FA"
 permission_read = "#A6E3A1"
 permission_write = "#F5C2E7"
 permission_exec = "#F38BA8"
-permission_none = "#313244"
+permission_none = "#6C7086"
 
 [special_files]
 [special_files.folders]
 "node_modules" = { h = 0, s = 0, l = 0.15 }
-"target" = "#313244"
-"dist" = "#313244"
+"target" = "#6C7086"
+"dist" = "#6C7086"
 ".git" = "#89B4FA"
-"build" = "#313244"
-".cache" = "#313244"
+"build" = "#6C7086"
+".cache" = "#6C7086"
 "*-env" = "#A6E3A1"
 "venv" = "#A6E3A1"
 ".env" = "#A6E3A1"
 "*.d" = "#CBA6F7"
-"*_cache" = "#313244"
-"*-cache" = "#313244"
+"*_cache" = "#6C7086"
+"*-cache" = "#6C7086"
 
 [special_files.dotfiles]
 ".gitignore" = "#94E2D5"
@@ -54,16 +54,16 @@ permission_none = "#313244"
 "Cargo.toml" = "#F38BA8"
 "go.mod" = "#94E2D5"
 "flake.nix" = "#89B4FA"
-"flake.lock" = "#313244"
+"flake.lock" = "#6C7086"
 "shell.nix" = "#89B4FA"
 "default.nix" = "#89B4FA"
 
 [special_files.patterns]
 "*rc" = "#94E2D5"
-"*.min.*" = "#313244"
+"*.min.*" = "#6C7086"
 "*.test.*" = "#A6E3A1"
 "*.spec.*" = "#A6E3A1"
-"*.lock" = "#313244"
+"*.lock" = "#6C7086"
 "*.config.*" = "#94E2D5"
 
 [extensions.groups]

--- a/themes/catppuccin_mocha.toml
+++ b/themes/catppuccin_mocha.toml
@@ -1,0 +1,158 @@
+name = "catppuccin_mocha"
+author = "Mohamed Achaq"
+description = "A soothing pastel theme for the high-spirited, featuring warm, cozy colors"
+
+[colors]
+file = "#CDD6F4"
+directory = "#89B4FA"
+symlink = "#CBA6F7"
+executable = "#A6E3A1"
+
+size = "#6C7086"
+date = "#6C7086"
+user = "#F5C2E7"
+group = "#6C7086"
+
+permission_dir = "#89B4FA"
+permission_read = "#A6E3A1"
+permission_write = "#F5C2E7"
+permission_exec = "#F38BA8"
+permission_none = "#313244"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#313244"
+"dist" = "#313244"
+".git" = "#89B4FA"
+"build" = "#313244"
+".cache" = "#313244"
+"*-env" = "#A6E3A1"
+"venv" = "#A6E3A1"
+".env" = "#A6E3A1"
+"*.d" = "#CBA6F7"
+"*_cache" = "#313244"
+"*-cache" = "#313244"
+
+[special_files.dotfiles]
+".gitignore" = "#94E2D5"
+".env" = "#89B4FA"
+".dockerignore" = "#94E2D5"
+".editorconfig" = "#94E2D5"
+".prettierrc" = "#94E2D5"
+".eslintrc" = "#94E2D5"
+".babelrc" = "#94E2D5"
+
+[special_files.exact_match]
+"Dockerfile" = "#94E2D5"
+"docker-compose.yml" = "#94E2D5"
+"Makefile" = "#F38BA8"
+"CMakeLists.txt" = "#F38BA8"
+"README.md" = "#89B4FA"
+"LICENSE" = "#89B4FA"
+"package.json" = "#89B4FA"
+"Cargo.toml" = "#F38BA8"
+"go.mod" = "#94E2D5"
+"flake.nix" = "#89B4FA"
+"flake.lock" = "#313244"
+"shell.nix" = "#89B4FA"
+"default.nix" = "#89B4FA"
+
+[special_files.patterns]
+"*rc" = "#94E2D5"
+"*.min.*" = "#313244"
+"*.test.*" = "#A6E3A1"
+"*.spec.*" = "#A6E3A1"
+"*.lock" = "#313244"
+"*.config.*" = "#94E2D5"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#F38BA8"
+python = "#A6E3A1"
+javascript = "#F9E2AF"
+typescript = "#94E2D5"
+java = "#F38BA8"
+csharp = "#A6E3A1"
+cpp = "#F38BA8"
+go = "#94E2D5"
+ruby = "#F38BA8"
+php = "#A6E3A1"
+swift = "#F38BA8"
+kotlin = "#A6E3A1"
+nix = "#94E2D5"
+
+markup = "#F5C2E7"
+style = "#A6E3A1"
+web_config = "#89B4FA"
+
+shell = "#A6E3A1"
+script = "#89B4FA"
+
+doc = "#CDD6F4"
+
+image = "#FAB387"
+video = "#FAB387"
+audio = "#FAB387"
+
+data = "#89B4FA"
+archive = "#F38BA8"
+
+rs = "#F38BA8"
+py = "#A6E3A1"
+js = "#F9E2AF"
+ts = "#94E2D5"
+jsx = "#F9E2AF"
+tsx = "#94E2D5"
+vue = "#A6E3A1"
+css = "#A6E3A1"
+scss = "#A6E3A1"
+html = "#F5C2E7"
+md = "#CDD6F4"
+json = "#89B4FA"
+yaml = "#89B4FA"
+toml = "#89B4FA"
+sql = "#94E2D5"

--- a/themes/dark.toml
+++ b/themes/dark.toml
@@ -1,0 +1,184 @@
+# lla dark theme
+name = "dark"
+author = "Mohamed Achaq"
+description = "A modern dark theme with enhanced visibility and rich colors for dark terminals"
+
+[colors]
+# Core UI Elements
+file = { r = 220, g = 223, b = 228 }      # Soft white for better readability
+directory = { r = 127, g = 222, b = 255 } # Cyan
+symlink = { r = 127, g = 222, b = 255 }   # Bright cyan
+executable = { r = 80, g = 250, b = 123 } # Bright green
+
+# Metadata
+size = { r = 98, g = 209, b = 150 }   # Soft green
+date = { r = 187, g = 154, b = 247 }  # Soft purple
+user = { r = 255, g = 121, b = 198 }  # Bright pink
+group = { r = 139, g = 148, b = 158 } # Muted gray
+
+# Permissions
+permission_dir = { r = 82, g = 139, b = 255 }    # Vibrant blue
+permission_read = { r = 80, g = 250, b = 123 }   # Bright green
+permission_write = { r = 255, g = 184, b = 108 } # Soft orange
+permission_exec = { r = 255, g = 121, b = 198 }  # Bright pink
+permission_none = { r = 68, g = 71, b = 90 }     # Dark gray
+
+[special_files]
+# Special Folders
+[special_files.folders]
+# Development folders
+"node_modules" = { r = 68, g = 71, b = 90 } # Dark gray
+"target" = { r = 68, g = 71, b = 90 }       # Dark gray
+"dist" = { r = 68, g = 71, b = 90 }         # Dark gray
+".git" = { r = 255, g = 121, b = 198 }      # Bright pink
+"build" = { r = 68, g = 71, b = 90 }        # Dark gray
+".cache" = { r = 68, g = 71, b = 90 }       # Dark gray
+
+# Environment folders
+"*-env" = { r = 80, g = 250, b = 123 } # Bright green
+"venv" = { r = 80, g = 250, b = 123 }  # Bright green
+".env" = { r = 80, g = 250, b = 123 }  # Bright green
+
+# Pattern matches for folders
+"*.d" = { r = 82, g = 139, b = 255 }   # Vibrant blue - Type definition folders
+"*_cache" = { r = 68, g = 71, b = 90 } # Dark gray - Cache folders
+"*-cache" = { r = 68, g = 71, b = 90 } # Dark gray - Cache folders
+
+# Dotfiles
+[special_files.dotfiles]
+".gitignore" = { r = 127, g = 222, b = 255 }    # Bright cyan
+".env" = { r = 255, g = 184, b = 108 }          # Soft orange
+".dockerignore" = { r = 127, g = 222, b = 255 } # Bright cyan
+".editorconfig" = { r = 127, g = 222, b = 255 } # Bright cyan
+".prettierrc" = { r = 127, g = 222, b = 255 }   # Bright cyan
+".eslintrc" = { r = 127, g = 222, b = 255 }     # Bright cyan
+".babelrc" = { r = 127, g = 222, b = 255 }      # Bright cyan
+
+# Exact matches
+[special_files.exact_match]
+"Dockerfile" = { r = 127, g = 222, b = 255 }         # Bright cyan
+"docker-compose.yml" = { r = 127, g = 222, b = 255 } # Bright cyan
+"Makefile" = { r = 255, g = 121, b = 198 }           # Bright pink
+"CMakeLists.txt" = { r = 255, g = 121, b = 198 }     # Bright pink
+"README.md" = { r = 255, g = 184, b = 108 }          # Soft orange
+"LICENSE" = { r = 255, g = 184, b = 108 }            # Soft orange
+"package.json" = { r = 255, g = 184, b = 108 }       # Soft orange
+"Cargo.toml" = { r = 255, g = 121, b = 198 }         # Bright pink
+"go.mod" = { r = 127, g = 222, b = 255 }             # Bright cyan
+"flake.nix" = { r = 82, g = 139, b = 255 }           # Vibrant blue
+"flake.lock" = { r = 68, g = 71, b = 90 }            # Dark gray
+"shell.nix" = { r = 82, g = 139, b = 255 }           # Vibrant blue
+"default.nix" = { r = 82, g = 139, b = 255 }         # Vibrant blue
+
+# Pattern matches
+[special_files.patterns]
+"*rc" = { r = 127, g = 222, b = 255 }        # Bright cyan
+"*.min.*" = { r = 68, g = 71, b = 90 }       # Dark gray
+"*.test.*" = { r = 80, g = 250, b = 123 }    # Bright green
+"*.spec.*" = { r = 80, g = 250, b = 123 }    # Bright green
+"*.lock" = { r = 68, g = 71, b = 90 }        # Dark gray
+"*.config.*" = { r = 127, g = 222, b = 255 } # Bright cyan
+
+[extensions.groups]
+# Development files
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+# Web files
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+# Shell and scripts
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+# Documentation
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+# Media files
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+# Data and config
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+# Development
+rust = { r = 255, g = 121, b = 198 }       # Bright pink
+python = { r = 80, g = 250, b = 123 }      # Bright green
+javascript = { r = 255, g = 184, b = 108 } # Soft orange
+typescript = { r = 82, g = 139, b = 255 }  # Vibrant blue
+java = { r = 255, g = 121, b = 198 }       # Bright pink
+csharp = { r = 80, g = 250, b = 123 }      # Bright green
+cpp = { r = 255, g = 121, b = 198 }        # Bright pink
+go = { r = 127, g = 222, b = 255 }         # Bright cyan
+ruby = { r = 255, g = 121, b = 198 }       # Bright pink
+php = { r = 80, g = 250, b = 123 }         # Bright green
+swift = { r = 255, g = 121, b = 198 }      # Bright pink
+kotlin = { r = 80, g = 250, b = 123 }      # Bright green
+nix = { r = 127, g = 222, b = 255 }        # Bright cyan
+
+# Web
+markup = { r = 187, g = 154, b = 247 }     # Soft purple
+style = { r = 127, g = 222, b = 255 }      # Bright cyan
+web_config = { r = 255, g = 184, b = 108 } # Soft orange
+
+# Shell and scripts
+shell = { r = 80, g = 250, b = 123 }   # Bright green
+script = { r = 255, g = 184, b = 108 } # Soft orange
+
+# Documentation
+doc = { r = 220, g = 223, b = 228 } # Soft white
+
+# Media
+image = { r = 187, g = 154, b = 247 } # Soft purple
+video = { r = 187, g = 154, b = 247 } # Soft purple
+audio = { r = 187, g = 154, b = 247 } # Soft purple
+
+# Data and config
+data = { r = 255, g = 184, b = 108 }    # Soft orange
+archive = { r = 255, g = 121, b = 198 } # Bright pink
+
+# Individual extension overrides
+rs = { r = 255, g = 121, b = 198 }   # Bright pink
+py = { r = 80, g = 250, b = 123 }    # Bright green
+js = { r = 255, g = 184, b = 108 }   # Soft orange
+ts = { r = 82, g = 139, b = 255 }    # Vibrant blue
+jsx = { r = 255, g = 184, b = 108 }  # Soft orange
+tsx = { r = 82, g = 139, b = 255 }   # Vibrant blue
+vue = { r = 80, g = 250, b = 123 }   # Bright green
+css = { r = 127, g = 222, b = 255 }  # Bright cyan
+scss = { r = 127, g = 222, b = 255 } # Bright cyan
+html = { r = 187, g = 154, b = 247 } # Soft purple
+md = { r = 220, g = 223, b = 228 }   # Soft white
+json = { r = 255, g = 184, b = 108 } # Soft orange
+yaml = { r = 255, g = 184, b = 108 } # Soft orange
+toml = { r = 255, g = 184, b = 108 } # Soft orange
+sql = { r = 127, g = 222, b = 255 }  # Bright cyan

--- a/themes/dark.toml
+++ b/themes/dark.toml
@@ -1,86 +1,74 @@
-# lla dark theme
 name = "dark"
 author = "Mohamed Achaq"
 description = "A modern dark theme with enhanced visibility and rich colors for dark terminals"
 
 [colors]
-# Core UI Elements
-file = { r = 220, g = 223, b = 228 }      # Soft white for better readability
-directory = { r = 127, g = 222, b = 255 } # Cyan
-symlink = { r = 127, g = 222, b = 255 }   # Bright cyan
-executable = { r = 80, g = 250, b = 123 } # Bright green
+file = { r = 220, g = 223, b = 228 }
+directory = { r = 127, g = 222, b = 255 }
+symlink = { r = 127, g = 222, b = 255 }
+executable = { r = 80, g = 250, b = 123 }
 
-# Metadata
-size = { r = 98, g = 209, b = 150 }   # Soft green
-date = { r = 187, g = 154, b = 247 }  # Soft purple
-user = { r = 255, g = 121, b = 198 }  # Bright pink
-group = { r = 139, g = 148, b = 158 } # Muted gray
+size = { r = 98, g = 209, b = 150 }
+date = { r = 187, g = 154, b = 247 }
+user = { r = 255, g = 121, b = 198 }
+group = { r = 139, g = 148, b = 158 }
 
-# Permissions
-permission_dir = { r = 82, g = 139, b = 255 }    # Vibrant blue
-permission_read = { r = 80, g = 250, b = 123 }   # Bright green
-permission_write = { r = 255, g = 184, b = 108 } # Soft orange
-permission_exec = { r = 255, g = 121, b = 198 }  # Bright pink
-permission_none = { r = 68, g = 71, b = 90 }     # Dark gray
+permission_dir = { r = 82, g = 139, b = 255 }
+permission_read = { r = 80, g = 250, b = 123 }
+permission_write = { r = 255, g = 184, b = 108 }
+permission_exec = { r = 255, g = 121, b = 198 }
+permission_none = { r = 68, g = 71, b = 90 }
 
 [special_files]
-# Special Folders
 [special_files.folders]
-# Development folders
-"node_modules" = { r = 68, g = 71, b = 90 } # Dark gray
-"target" = { r = 68, g = 71, b = 90 }       # Dark gray
-"dist" = { r = 68, g = 71, b = 90 }         # Dark gray
-".git" = { r = 255, g = 121, b = 198 }      # Bright pink
-"build" = { r = 68, g = 71, b = 90 }        # Dark gray
-".cache" = { r = 68, g = 71, b = 90 }       # Dark gray
+"node_modules" = { r = 68, g = 71, b = 90 }
+"target" = { r = 68, g = 71, b = 90 }
+"dist" = { r = 68, g = 71, b = 90 }
+".git" = { r = 255, g = 121, b = 198 }
+"build" = { r = 68, g = 71, b = 90 }
+".cache" = { r = 68, g = 71, b = 90 }
 
-# Environment folders
-"*-env" = { r = 80, g = 250, b = 123 } # Bright green
-"venv" = { r = 80, g = 250, b = 123 }  # Bright green
-".env" = { r = 80, g = 250, b = 123 }  # Bright green
+"*-env" = { r = 80, g = 250, b = 123 }
+"venv" = { r = 80, g = 250, b = 123 }
+".env" = { r = 80, g = 250, b = 123 }
 
-# Pattern matches for folders
-"*.d" = { r = 82, g = 139, b = 255 }   # Vibrant blue - Type definition folders
-"*_cache" = { r = 68, g = 71, b = 90 } # Dark gray - Cache folders
-"*-cache" = { r = 68, g = 71, b = 90 } # Dark gray - Cache folders
+"*.d" = { r = 82, g = 139, b = 255 }
+"*_cache" = { r = 68, g = 71, b = 90 }
+"*-cache" = { r = 68, g = 71, b = 90 }
 
-# Dotfiles
 [special_files.dotfiles]
-".gitignore" = { r = 127, g = 222, b = 255 }    # Bright cyan
-".env" = { r = 255, g = 184, b = 108 }          # Soft orange
-".dockerignore" = { r = 127, g = 222, b = 255 } # Bright cyan
-".editorconfig" = { r = 127, g = 222, b = 255 } # Bright cyan
-".prettierrc" = { r = 127, g = 222, b = 255 }   # Bright cyan
-".eslintrc" = { r = 127, g = 222, b = 255 }     # Bright cyan
-".babelrc" = { r = 127, g = 222, b = 255 }      # Bright cyan
+".gitignore" = { r = 127, g = 222, b = 255 }
+".env" = { r = 255, g = 184, b = 108 }
+".dockerignore" = { r = 127, g = 222, b = 255 }
+".editorconfig" = { r = 127, g = 222, b = 255 }
+".prettierrc" = { r = 127, g = 222, b = 255 }
+".eslintrc" = { r = 127, g = 222, b = 255 }
+".babelrc" = { r = 127, g = 222, b = 255 }
 
-# Exact matches
 [special_files.exact_match]
-"Dockerfile" = { r = 127, g = 222, b = 255 }         # Bright cyan
-"docker-compose.yml" = { r = 127, g = 222, b = 255 } # Bright cyan
-"Makefile" = { r = 255, g = 121, b = 198 }           # Bright pink
-"CMakeLists.txt" = { r = 255, g = 121, b = 198 }     # Bright pink
-"README.md" = { r = 255, g = 184, b = 108 }          # Soft orange
-"LICENSE" = { r = 255, g = 184, b = 108 }            # Soft orange
-"package.json" = { r = 255, g = 184, b = 108 }       # Soft orange
-"Cargo.toml" = { r = 255, g = 121, b = 198 }         # Bright pink
-"go.mod" = { r = 127, g = 222, b = 255 }             # Bright cyan
-"flake.nix" = { r = 82, g = 139, b = 255 }           # Vibrant blue
-"flake.lock" = { r = 68, g = 71, b = 90 }            # Dark gray
-"shell.nix" = { r = 82, g = 139, b = 255 }           # Vibrant blue
-"default.nix" = { r = 82, g = 139, b = 255 }         # Vibrant blue
+"Dockerfile" = { r = 127, g = 222, b = 255 }
+"docker-compose.yml" = { r = 127, g = 222, b = 255 }
+"Makefile" = { r = 255, g = 121, b = 198 }
+"CMakeLists.txt" = { r = 255, g = 121, b = 198 }
+"README.md" = { r = 255, g = 184, b = 108 }
+"LICENSE" = { r = 255, g = 184, b = 108 }
+"package.json" = { r = 255, g = 184, b = 108 }
+"Cargo.toml" = { r = 255, g = 121, b = 198 }
+"go.mod" = { r = 127, g = 222, b = 255 }
+"flake.nix" = { r = 82, g = 139, b = 255 }
+"flake.lock" = { r = 68, g = 71, b = 90 }
+"shell.nix" = { r = 82, g = 139, b = 255 }
+"default.nix" = { r = 82, g = 139, b = 255 }
 
-# Pattern matches
 [special_files.patterns]
-"*rc" = { r = 127, g = 222, b = 255 }        # Bright cyan
-"*.min.*" = { r = 68, g = 71, b = 90 }       # Dark gray
-"*.test.*" = { r = 80, g = 250, b = 123 }    # Bright green
-"*.spec.*" = { r = 80, g = 250, b = 123 }    # Bright green
-"*.lock" = { r = 68, g = 71, b = 90 }        # Dark gray
-"*.config.*" = { r = 127, g = 222, b = 255 } # Bright cyan
+"*rc" = { r = 127, g = 222, b = 255 }
+"*.min.*" = { r = 68, g = 71, b = 90 }
+"*.test.*" = { r = 80, g = 250, b = 123 }
+"*.spec.*" = { r = 80, g = 250, b = 123 }
+"*.lock" = { r = 68, g = 71, b = 90 }
+"*.config.*" = { r = 127, g = 222, b = 255 }
 
 [extensions.groups]
-# Development files
 rust = ["rs", "toml"]
 python = ["py", "pyi", "pyw", "ipynb"]
 javascript = ["js", "mjs", "cjs", "jsx"]
@@ -95,16 +83,13 @@ swift = ["swift"]
 kotlin = ["kt", "kts"]
 nix = ["nix"]
 
-# Web files
 markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
 style = ["css", "scss", "sass", "less", "styl"]
 web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
 
-# Shell and scripts
 shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
 script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
 
-# Documentation
 doc = [
     "md",
     "rst",
@@ -120,65 +105,56 @@ doc = [
     "rtf",
 ]
 
-# Media files
 image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
 video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
 audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
 
-# Data and config
 data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
 archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
 
 [extensions.colors]
-# Development
-rust = { r = 255, g = 121, b = 198 }       # Bright pink
-python = { r = 80, g = 250, b = 123 }      # Bright green
-javascript = { r = 255, g = 184, b = 108 } # Soft orange
-typescript = { r = 82, g = 139, b = 255 }  # Vibrant blue
-java = { r = 255, g = 121, b = 198 }       # Bright pink
-csharp = { r = 80, g = 250, b = 123 }      # Bright green
-cpp = { r = 255, g = 121, b = 198 }        # Bright pink
-go = { r = 127, g = 222, b = 255 }         # Bright cyan
-ruby = { r = 255, g = 121, b = 198 }       # Bright pink
-php = { r = 80, g = 250, b = 123 }         # Bright green
-swift = { r = 255, g = 121, b = 198 }      # Bright pink
-kotlin = { r = 80, g = 250, b = 123 }      # Bright green
-nix = { r = 127, g = 222, b = 255 }        # Bright cyan
+rust = { r = 255, g = 121, b = 198 }
+python = { r = 80, g = 250, b = 123 }
+javascript = { r = 255, g = 184, b = 108 }
+typescript = { r = 82, g = 139, b = 255 }
+java = { r = 255, g = 121, b = 198 }
+csharp = { r = 80, g = 250, b = 123 }
+cpp = { r = 255, g = 121, b = 198 }
+go = { r = 127, g = 222, b = 255 }
+ruby = { r = 255, g = 121, b = 198 }
+php = { r = 80, g = 250, b = 123 }
+swift = { r = 255, g = 121, b = 198 }
+kotlin = { r = 80, g = 250, b = 123 }
+nix = { r = 127, g = 222, b = 255 }
 
-# Web
-markup = { r = 187, g = 154, b = 247 }     # Soft purple
-style = { r = 127, g = 222, b = 255 }      # Bright cyan
-web_config = { r = 255, g = 184, b = 108 } # Soft orange
+markup = { r = 187, g = 154, b = 247 }
+style = { r = 127, g = 222, b = 255 }
+web_config = { r = 255, g = 184, b = 108 }
 
-# Shell and scripts
-shell = { r = 80, g = 250, b = 123 }   # Bright green
-script = { r = 255, g = 184, b = 108 } # Soft orange
+shell = { r = 80, g = 250, b = 123 }
+script = { r = 255, g = 184, b = 108 }
 
-# Documentation
-doc = { r = 220, g = 223, b = 228 } # Soft white
+doc = { r = 220, g = 223, b = 228 }
 
-# Media
-image = { r = 187, g = 154, b = 247 } # Soft purple
-video = { r = 187, g = 154, b = 247 } # Soft purple
-audio = { r = 187, g = 154, b = 247 } # Soft purple
+image = { r = 187, g = 154, b = 247 }
+video = { r = 187, g = 154, b = 247 }
+audio = { r = 187, g = 154, b = 247 }
 
-# Data and config
-data = { r = 255, g = 184, b = 108 }    # Soft orange
-archive = { r = 255, g = 121, b = 198 } # Bright pink
+data = { r = 255, g = 184, b = 108 }
+archive = { r = 255, g = 121, b = 198 }
 
-# Individual extension overrides
-rs = { r = 255, g = 121, b = 198 }   # Bright pink
-py = { r = 80, g = 250, b = 123 }    # Bright green
-js = { r = 255, g = 184, b = 108 }   # Soft orange
-ts = { r = 82, g = 139, b = 255 }    # Vibrant blue
-jsx = { r = 255, g = 184, b = 108 }  # Soft orange
-tsx = { r = 82, g = 139, b = 255 }   # Vibrant blue
-vue = { r = 80, g = 250, b = 123 }   # Bright green
-css = { r = 127, g = 222, b = 255 }  # Bright cyan
-scss = { r = 127, g = 222, b = 255 } # Bright cyan
-html = { r = 187, g = 154, b = 247 } # Soft purple
-md = { r = 220, g = 223, b = 228 }   # Soft white
-json = { r = 255, g = 184, b = 108 } # Soft orange
-yaml = { r = 255, g = 184, b = 108 } # Soft orange
-toml = { r = 255, g = 184, b = 108 } # Soft orange
-sql = { r = 127, g = 222, b = 255 }  # Bright cyan
+rs = { r = 255, g = 121, b = 198 }
+py = { r = 80, g = 250, b = 123 }
+js = { r = 255, g = 184, b = 108 }
+ts = { r = 82, g = 139, b = 255 }
+jsx = { r = 255, g = 184, b = 108 }
+tsx = { r = 82, g = 139, b = 255 }
+vue = { r = 80, g = 250, b = 123 }
+css = { r = 127, g = 222, b = 255 }
+scss = { r = 127, g = 222, b = 255 }
+html = { r = 187, g = 154, b = 247 }
+md = { r = 220, g = 223, b = 228 }
+json = { r = 255, g = 184, b = 108 }
+yaml = { r = 255, g = 184, b = 108 }
+toml = { r = 255, g = 184, b = 108 }
+sql = { r = 127, g = 222, b = 255 }

--- a/themes/default.toml
+++ b/themes/default.toml
@@ -1,86 +1,74 @@
-# lla default theme
 name = "default"
 author = "Mohamed Achaq"
 description = "A modern, high-contrast theme for lla with carefully selected colors for optimal visibility"
 
 [colors]
-# Core UI Elements
-file = { r = 220, g = 220, b = 220 }      # Light Gray - Better than pure white for eye comfort
-directory = { r = 74, g = 144, b = 226 }  # Vibrant Blue - More saturated and visible
-symlink = { r = 42, g = 161, b = 152 }    # Teal - Distinct from directory
-executable = { r = 126, g = 211, b = 33 } # Lime Green - More visible than traditional green
+file = { r = 220, g = 220, b = 220 }
+directory = { r = 74, g = 144, b = 226 }
+symlink = { r = 42, g = 161, b = 152 }
+executable = { r = 126, g = 211, b = 33 }
 
-# Metadata
-size = { r = 42, g = 161, b = 152 }   # Teal - Softer than pure green
-date = { r = 170, g = 170, b = 170 }  # Medium Gray - Subtle but readable
-user = { r = 108, g = 113, b = 196 }  # Soft Purple - Distinct from other elements
-group = { r = 146, g = 146, b = 146 } # Darker Gray - Subtle but visible
+size = { r = 42, g = 161, b = 152 }
+date = { r = 170, g = 170, b = 170 }
+user = { r = 108, g = 113, b = 196 }
+group = { r = 146, g = 146, b = 146 }
 
-# Permissions
-permission_dir = { r = 74, g = 144, b = 226 }   # Vibrant Blue - Matches directory
-permission_read = { r = 42, g = 161, b = 152 }  # Teal - Clear and visible
-permission_write = { r = 203, g = 75, b = 22 }  # Orange - Warning color
-permission_exec = { r = 126, g = 211, b = 33 }  # Lime Green - Matches executable
-permission_none = { r = 146, g = 146, b = 146 } # Darker Gray - Clearly shows lack of permission
+permission_dir = { r = 74, g = 144, b = 226 }
+permission_read = { r = 42, g = 161, b = 152 }
+permission_write = { r = 203, g = 75, b = 22 }
+permission_exec = { r = 126, g = 211, b = 33 }
+permission_none = { r = 146, g = 146, b = 146 }
 
 [special_files]
-# Special Folders
 [special_files.folders]
-# Development folders
-"node_modules" = { r = 146, g = 146, b = 146 } # Darker Gray
-"target" = { r = 146, g = 146, b = 146 }       # Darker Gray
-"dist" = { r = 146, g = 146, b = 146 }         # Darker Gray
-".git" = { r = 203, g = 75, b = 22 }           # Orange - More visible than red
-"build" = { r = 146, g = 146, b = 146 }        # Darker Gray
-".cache" = { r = 146, g = 146, b = 146 }       # Darker Gray
+"node_modules" = { r = 146, g = 146, b = 146 }
+"target" = { r = 146, g = 146, b = 146 }
+"dist" = { r = 146, g = 146, b = 146 }
+".git" = { r = 203, g = 75, b = 22 }
+"build" = { r = 146, g = 146, b = 146 }
+".cache" = { r = 146, g = 146, b = 146 }
 
-# Environment folders
-"*-env" = { r = 126, g = 211, b = 33 } # Lime Green
-"venv" = { r = 126, g = 211, b = 33 }  # Lime Green
-".env" = { r = 126, g = 211, b = 33 }  # Lime Green
+"*-env" = { r = 126, g = 211, b = 33 }
+"venv" = { r = 126, g = 211, b = 33 }
+".env" = { r = 126, g = 211, b = 33 }
 
-# Pattern matches for folders
-"*.d" = { r = 74, g = 144, b = 226 }      # Vibrant Blue
-"*_cache" = { r = 146, g = 146, b = 146 } # Darker Gray
-"*-cache" = { r = 146, g = 146, b = 146 } # Darker Gray
+"*.d" = { r = 74, g = 144, b = 226 }
+"*_cache" = { r = 146, g = 146, b = 146 }
+"*-cache" = { r = 146, g = 146, b = 146 }
 
-# Dotfiles
 [special_files.dotfiles]
-".gitignore" = { r = 42, g = 161, b = 152 }    # Teal
-".env" = { r = 203, g = 75, b = 22 }           # Orange - Important files
-".dockerignore" = { r = 42, g = 161, b = 152 } # Teal
-".editorconfig" = { r = 42, g = 161, b = 152 } # Teal
-".prettierrc" = { r = 42, g = 161, b = 152 }   # Teal
-".eslintrc" = { r = 42, g = 161, b = 152 }     # Teal
-".babelrc" = { r = 42, g = 161, b = 152 }      # Teal
+".gitignore" = { r = 42, g = 161, b = 152 }
+".env" = { r = 203, g = 75, b = 22 }
+".dockerignore" = { r = 42, g = 161, b = 152 }
+".editorconfig" = { r = 42, g = 161, b = 152 }
+".prettierrc" = { r = 42, g = 161, b = 152 }
+".eslintrc" = { r = 42, g = 161, b = 152 }
+".babelrc" = { r = 42, g = 161, b = 152 }
 
-# Exact matches
 [special_files.exact_match]
-"Dockerfile" = { r = 42, g = 161, b = 152 }         # Teal
-"docker-compose.yml" = { r = 42, g = 161, b = 152 } # Teal
-"Makefile" = { r = 211, g = 54, b = 130 }           # Deep Pink - Important build files
-"CMakeLists.txt" = { r = 211, g = 54, b = 130 }     # Deep Pink
-"README.md" = { r = 255, g = 199, b = 6 }           # Gold - Important documentation
-"LICENSE" = { r = 255, g = 199, b = 6 }             # Gold
-"package.json" = { r = 203, g = 75, b = 22 }        # Orange
-"Cargo.toml" = { r = 203, g = 75, b = 22 }          # Orange
-"go.mod" = { r = 42, g = 161, b = 152 }             # Teal
-"flake.nix" = { r = 108, g = 113, b = 196 }         # Soft Purple
-"flake.lock" = { r = 146, g = 146, b = 146 }        # Darker Gray
-"shell.nix" = { r = 108, g = 113, b = 196 }         # Soft Purple
-"default.nix" = { r = 108, g = 113, b = 196 }       # Soft Purple
+"Dockerfile" = { r = 42, g = 161, b = 152 }
+"docker-compose.yml" = { r = 42, g = 161, b = 152 }
+"Makefile" = { r = 211, g = 54, b = 130 }
+"CMakeLists.txt" = { r = 211, g = 54, b = 130 }
+"README.md" = { r = 255, g = 199, b = 6 }
+"LICENSE" = { r = 255, g = 199, b = 6 }
+"package.json" = { r = 203, g = 75, b = 22 }
+"Cargo.toml" = { r = 203, g = 75, b = 22 }
+"go.mod" = { r = 42, g = 161, b = 152 }
+"flake.nix" = { r = 108, g = 113, b = 196 }
+"flake.lock" = { r = 146, g = 146, b = 146 }
+"shell.nix" = { r = 108, g = 113, b = 196 }
+"default.nix" = { r = 108, g = 113, b = 196 }
 
-# Pattern matches
 [special_files.patterns]
-"*rc" = { r = 42, g = 161, b = 152 }        # Teal
-"*.min.*" = { r = 146, g = 146, b = 146 }   # Darker Gray
-"*.test.*" = { r = 126, g = 211, b = 33 }   # Lime Green
-"*.spec.*" = { r = 126, g = 211, b = 33 }   # Lime Green
-"*.lock" = { r = 146, g = 146, b = 146 }    # Darker Gray
-"*.config.*" = { r = 42, g = 161, b = 152 } # Teal
+"*rc" = { r = 42, g = 161, b = 152 }
+"*.min.*" = { r = 146, g = 146, b = 146 }
+"*.test.*" = { r = 126, g = 211, b = 33 }
+"*.spec.*" = { r = 126, g = 211, b = 33 }
+"*.lock" = { r = 146, g = 146, b = 146 }
+"*.config.*" = { r = 42, g = 161, b = 152 }
 
 [extensions.groups]
-# Development files
 rust = ["rs", "toml", "lock"]
 script = ["js", "mjs", "cjs", "jsx", "json", "json5", "yaml", "yml"]
 typescript = ["ts", "tsx", "d.ts"]
@@ -123,33 +111,31 @@ archive = ["zip", "tar", "gz", "rar", "7z", "iso", "dmg", "exe", "dll"]
 data = ["csv", "tsv", "sqlite", "db"]
 
 [extensions.colors]
-# Development
-rust = { r = 211, g = 54, b = 130 }       # Deep Pink
-script = { r = 255, g = 199, b = 6 }      # Gold
-typescript = { r = 74, g = 144, b = 226 } # Vibrant Blue
-markup = { r = 108, g = 113, b = 196 }    # Soft Purple
-style = { r = 42, g = 161, b = 152 }      # Teal
-executable = { r = 126, g = 211, b = 33 } # Lime Green
-doc = { r = 220, g = 220, b = 220 }       # Light Gray
-media = { r = 211, g = 54, b = 130 }      # Deep Pink
-archive = { r = 203, g = 75, b = 22 }     # Orange
-data = { r = 255, g = 199, b = 6 }        # Gold
+rust = { r = 211, g = 54, b = 130 }
+script = { r = 255, g = 199, b = 6 }
+typescript = { r = 74, g = 144, b = 226 }
+markup = { r = 108, g = 113, b = 196 }
+style = { r = 42, g = 161, b = 152 }
+executable = { r = 126, g = 211, b = 33 }
+doc = { r = 220, g = 220, b = 220 }
+media = { r = 211, g = 54, b = 130 }
+archive = { r = 203, g = 75, b = 22 }
+data = { r = 255, g = 199, b = 6 }
 
-# Individual extension overrides
-rs = { r = 211, g = 54, b = 130 }    # Deep Pink
-toml = { r = 211, g = 54, b = 130 }  # Deep Pink
-lock = { r = 146, g = 146, b = 146 } # Darker Gray
-js = { r = 255, g = 199, b = 6 }     # Gold
-json = { r = 255, g = 199, b = 6 }   # Gold
-yaml = { r = 255, g = 199, b = 6 }   # Gold
-yml = { r = 255, g = 199, b = 6 }    # Gold
-ts = { r = 74, g = 144, b = 226 }    # Vibrant Blue
-tsx = { r = 74, g = 144, b = 226 }   # Vibrant Blue
-html = { r = 108, g = 113, b = 196 } # Soft Purple
-xml = { r = 108, g = 113, b = 196 }  # Soft Purple
-css = { r = 42, g = 161, b = 152 }   # Teal
-scss = { r = 42, g = 161, b = 152 }  # Teal
-py = { r = 126, g = 211, b = 33 }    # Lime Green
-sh = { r = 126, g = 211, b = 33 }    # Lime Green
-md = { r = 220, g = 220, b = 220 }   # Light Gray
-txt = { r = 220, g = 220, b = 220 }  # Light Gray
+rs = { r = 211, g = 54, b = 130 }
+toml = { r = 211, g = 54, b = 130 }
+lock = { r = 146, g = 146, b = 146 }
+js = { r = 255, g = 199, b = 6 }
+json = { r = 255, g = 199, b = 6 }
+yaml = { r = 255, g = 199, b = 6 }
+yml = { r = 255, g = 199, b = 6 }
+ts = { r = 74, g = 144, b = 226 }
+tsx = { r = 74, g = 144, b = 226 }
+html = { r = 108, g = 113, b = 196 }
+xml = { r = 108, g = 113, b = 196 }
+css = { r = 42, g = 161, b = 152 }
+scss = { r = 42, g = 161, b = 152 }
+py = { r = 126, g = 211, b = 33 }
+sh = { r = 126, g = 211, b = 33 }
+md = { r = 220, g = 220, b = 220 }
+txt = { r = 220, g = 220, b = 220 }

--- a/themes/default.toml
+++ b/themes/default.toml
@@ -1,0 +1,155 @@
+# lla default theme
+name = "default"
+author = "Mohamed Achaq"
+description = "A modern, high-contrast theme for lla with carefully selected colors for optimal visibility"
+
+[colors]
+# Core UI Elements
+file = { r = 220, g = 220, b = 220 }      # Light Gray - Better than pure white for eye comfort
+directory = { r = 74, g = 144, b = 226 }  # Vibrant Blue - More saturated and visible
+symlink = { r = 42, g = 161, b = 152 }    # Teal - Distinct from directory
+executable = { r = 126, g = 211, b = 33 } # Lime Green - More visible than traditional green
+
+# Metadata
+size = { r = 42, g = 161, b = 152 }   # Teal - Softer than pure green
+date = { r = 170, g = 170, b = 170 }  # Medium Gray - Subtle but readable
+user = { r = 108, g = 113, b = 196 }  # Soft Purple - Distinct from other elements
+group = { r = 146, g = 146, b = 146 } # Darker Gray - Subtle but visible
+
+# Permissions
+permission_dir = { r = 74, g = 144, b = 226 }   # Vibrant Blue - Matches directory
+permission_read = { r = 42, g = 161, b = 152 }  # Teal - Clear and visible
+permission_write = { r = 203, g = 75, b = 22 }  # Orange - Warning color
+permission_exec = { r = 126, g = 211, b = 33 }  # Lime Green - Matches executable
+permission_none = { r = 146, g = 146, b = 146 } # Darker Gray - Clearly shows lack of permission
+
+[special_files]
+# Special Folders
+[special_files.folders]
+# Development folders
+"node_modules" = { r = 146, g = 146, b = 146 } # Darker Gray
+"target" = { r = 146, g = 146, b = 146 }       # Darker Gray
+"dist" = { r = 146, g = 146, b = 146 }         # Darker Gray
+".git" = { r = 203, g = 75, b = 22 }           # Orange - More visible than red
+"build" = { r = 146, g = 146, b = 146 }        # Darker Gray
+".cache" = { r = 146, g = 146, b = 146 }       # Darker Gray
+
+# Environment folders
+"*-env" = { r = 126, g = 211, b = 33 } # Lime Green
+"venv" = { r = 126, g = 211, b = 33 }  # Lime Green
+".env" = { r = 126, g = 211, b = 33 }  # Lime Green
+
+# Pattern matches for folders
+"*.d" = { r = 74, g = 144, b = 226 }      # Vibrant Blue
+"*_cache" = { r = 146, g = 146, b = 146 } # Darker Gray
+"*-cache" = { r = 146, g = 146, b = 146 } # Darker Gray
+
+# Dotfiles
+[special_files.dotfiles]
+".gitignore" = { r = 42, g = 161, b = 152 }    # Teal
+".env" = { r = 203, g = 75, b = 22 }           # Orange - Important files
+".dockerignore" = { r = 42, g = 161, b = 152 } # Teal
+".editorconfig" = { r = 42, g = 161, b = 152 } # Teal
+".prettierrc" = { r = 42, g = 161, b = 152 }   # Teal
+".eslintrc" = { r = 42, g = 161, b = 152 }     # Teal
+".babelrc" = { r = 42, g = 161, b = 152 }      # Teal
+
+# Exact matches
+[special_files.exact_match]
+"Dockerfile" = { r = 42, g = 161, b = 152 }         # Teal
+"docker-compose.yml" = { r = 42, g = 161, b = 152 } # Teal
+"Makefile" = { r = 211, g = 54, b = 130 }           # Deep Pink - Important build files
+"CMakeLists.txt" = { r = 211, g = 54, b = 130 }     # Deep Pink
+"README.md" = { r = 255, g = 199, b = 6 }           # Gold - Important documentation
+"LICENSE" = { r = 255, g = 199, b = 6 }             # Gold
+"package.json" = { r = 203, g = 75, b = 22 }        # Orange
+"Cargo.toml" = { r = 203, g = 75, b = 22 }          # Orange
+"go.mod" = { r = 42, g = 161, b = 152 }             # Teal
+"flake.nix" = { r = 108, g = 113, b = 196 }         # Soft Purple
+"flake.lock" = { r = 146, g = 146, b = 146 }        # Darker Gray
+"shell.nix" = { r = 108, g = 113, b = 196 }         # Soft Purple
+"default.nix" = { r = 108, g = 113, b = 196 }       # Soft Purple
+
+# Pattern matches
+[special_files.patterns]
+"*rc" = { r = 42, g = 161, b = 152 }        # Teal
+"*.min.*" = { r = 146, g = 146, b = 146 }   # Darker Gray
+"*.test.*" = { r = 126, g = 211, b = 33 }   # Lime Green
+"*.spec.*" = { r = 126, g = 211, b = 33 }   # Lime Green
+"*.lock" = { r = 146, g = 146, b = 146 }    # Darker Gray
+"*.config.*" = { r = 42, g = 161, b = 152 } # Teal
+
+[extensions.groups]
+# Development files
+rust = ["rs", "toml", "lock"]
+script = ["js", "mjs", "cjs", "jsx", "json", "json5", "yaml", "yml"]
+typescript = ["ts", "tsx", "d.ts"]
+markup = ["html", "htm", "xml", "vue", "ejs"]
+style = ["css", "scss", "sass", "less", "conf", "config", "ini", "env"]
+executable = [
+    "py",
+    "pyi",
+    "pyw",
+    "sh",
+    "bash",
+    "zsh",
+    "fish",
+    "bat",
+    "cmd",
+    "ps1",
+]
+doc = ["md", "rst", "txt", "doc", "docx", "pdf", "org", "wiki"]
+media = [
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "svg",
+    "bmp",
+    "ico",
+    "webp",
+    "tiff",
+    "mp4",
+    "mov",
+    "avi",
+    "mkv",
+    "flv",
+    "wmv",
+    "webm",
+    "m4v",
+    "3gp",
+]
+archive = ["zip", "tar", "gz", "rar", "7z", "iso", "dmg", "exe", "dll"]
+data = ["csv", "tsv", "sqlite", "db"]
+
+[extensions.colors]
+# Development
+rust = { r = 211, g = 54, b = 130 }       # Deep Pink
+script = { r = 255, g = 199, b = 6 }      # Gold
+typescript = { r = 74, g = 144, b = 226 } # Vibrant Blue
+markup = { r = 108, g = 113, b = 196 }    # Soft Purple
+style = { r = 42, g = 161, b = 152 }      # Teal
+executable = { r = 126, g = 211, b = 33 } # Lime Green
+doc = { r = 220, g = 220, b = 220 }       # Light Gray
+media = { r = 211, g = 54, b = 130 }      # Deep Pink
+archive = { r = 203, g = 75, b = 22 }     # Orange
+data = { r = 255, g = 199, b = 6 }        # Gold
+
+# Individual extension overrides
+rs = { r = 211, g = 54, b = 130 }    # Deep Pink
+toml = { r = 211, g = 54, b = 130 }  # Deep Pink
+lock = { r = 146, g = 146, b = 146 } # Darker Gray
+js = { r = 255, g = 199, b = 6 }     # Gold
+json = { r = 255, g = 199, b = 6 }   # Gold
+yaml = { r = 255, g = 199, b = 6 }   # Gold
+yml = { r = 255, g = 199, b = 6 }    # Gold
+ts = { r = 74, g = 144, b = 226 }    # Vibrant Blue
+tsx = { r = 74, g = 144, b = 226 }   # Vibrant Blue
+html = { r = 108, g = 113, b = 196 } # Soft Purple
+xml = { r = 108, g = 113, b = 196 }  # Soft Purple
+css = { r = 42, g = 161, b = 152 }   # Teal
+scss = { r = 42, g = 161, b = 152 }  # Teal
+py = { r = 126, g = 211, b = 33 }    # Lime Green
+sh = { r = 126, g = 211, b = 33 }    # Lime Green
+md = { r = 220, g = 220, b = 220 }   # Light Gray
+txt = { r = 220, g = 220, b = 220 }  # Light Gray

--- a/themes/dracula.toml
+++ b/themes/dracula.toml
@@ -1,0 +1,158 @@
+name = "dracula"
+author = "Mohamed Achaq"
+description = "A dark theme featuring the classic Dracula color scheme with vibrant colors and high contrast"
+
+[colors]
+file = "#F8F8F2"
+directory = "#BD93F9"
+symlink = "#FF79C6"
+executable = "#50FA7B"
+
+size = "#6272A4"
+date = "#6272A4"
+user = "#FF79C6"
+group = "#6272A4"
+
+permission_dir = "#BD93F9"
+permission_read = "#50FA7B"
+permission_write = "#FF79C6"
+permission_exec = "#FF5555"
+permission_none = "#44475A"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#44475A"
+"dist" = "#44475A"
+".git" = "#BD93F9"
+"build" = "#44475A"
+".cache" = "#44475A"
+"*-env" = "#50FA7B"
+"venv" = "#50FA7B"
+".env" = "#50FA7B"
+"*.d" = "#FF79C6"
+"*_cache" = "#44475A"
+"*-cache" = "#44475A"
+
+[special_files.dotfiles]
+".gitignore" = "#8BE9FD"
+".env" = "#BD93F9"
+".dockerignore" = "#8BE9FD"
+".editorconfig" = "#8BE9FD"
+".prettierrc" = "#8BE9FD"
+".eslintrc" = "#8BE9FD"
+".babelrc" = "#8BE9FD"
+
+[special_files.exact_match]
+"Dockerfile" = "#8BE9FD"
+"docker-compose.yml" = "#8BE9FD"
+"Makefile" = "#FF5555"
+"CMakeLists.txt" = "#FF5555"
+"README.md" = "#BD93F9"
+"LICENSE" = "#BD93F9"
+"package.json" = "#BD93F9"
+"Cargo.toml" = "#FF5555"
+"go.mod" = "#8BE9FD"
+"flake.nix" = "#BD93F9"
+"flake.lock" = "#44475A"
+"shell.nix" = "#BD93F9"
+"default.nix" = "#BD93F9"
+
+[special_files.patterns]
+"*rc" = "#8BE9FD"
+"*.min.*" = "#44475A"
+"*.test.*" = "#50FA7B"
+"*.spec.*" = "#50FA7B"
+"*.lock" = "#44475A"
+"*.config.*" = "#8BE9FD"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF5555"
+python = "#50FA7B"
+javascript = "#F1FA8C"
+typescript = "#8BE9FD"
+java = "#FF5555"
+csharp = "#50FA7B"
+cpp = "#FF5555"
+go = "#8BE9FD"
+ruby = "#FF5555"
+php = "#50FA7B"
+swift = "#FF5555"
+kotlin = "#50FA7B"
+nix = "#8BE9FD"
+
+markup = "#FF79C6"
+style = "#50FA7B"
+web_config = "#BD93F9"
+
+shell = "#50FA7B"
+script = "#BD93F9"
+
+doc = "#F8F8F2"
+
+image = "#FFB86C"
+video = "#FFB86C"
+audio = "#FFB86C"
+
+data = "#BD93F9"
+archive = "#FF5555"
+
+rs = "#FF5555"
+py = "#50FA7B"
+js = "#F1FA8C"
+ts = "#8BE9FD"
+jsx = "#F1FA8C"
+tsx = "#8BE9FD"
+vue = "#50FA7B"
+css = "#50FA7B"
+scss = "#50FA7B"
+html = "#FF79C6"
+md = "#F8F8F2"
+json = "#BD93F9"
+yaml = "#BD93F9"
+toml = "#BD93F9"
+sql = "#8BE9FD"

--- a/themes/gruvbox_dark.toml
+++ b/themes/gruvbox_dark.toml
@@ -1,0 +1,158 @@
+name = "gruvbox_dark"
+author = "Mohamed Achaq"
+description = "A retro groove color scheme with warm, earthy tones and high contrast"
+
+[colors]
+file = "#EBDBB2"
+directory = "#B8BB26"
+symlink = "#83A598"
+executable = "#98971A"
+
+size = "#928374"
+date = "#928374"
+user = "#D3869B"
+group = "#928374"
+
+permission_dir = "#B8BB26"
+permission_read = "#98971A"
+permission_write = "#D3869B"
+permission_exec = "#FB4934"
+permission_none = "#3C3836"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#3C3836"
+"dist" = "#3C3836"
+".git" = "#B8BB26"
+"build" = "#3C3836"
+".cache" = "#3C3836"
+"*-env" = "#98971A"
+"venv" = "#98971A"
+".env" = "#98971A"
+"*.d" = "#83A598"
+"*_cache" = "#3C3836"
+"*-cache" = "#3C3836"
+
+[special_files.dotfiles]
+".gitignore" = "#458588"
+".env" = "#B8BB26"
+".dockerignore" = "#458588"
+".editorconfig" = "#458588"
+".prettierrc" = "#458588"
+".eslintrc" = "#458588"
+".babelrc" = "#458588"
+
+[special_files.exact_match]
+"Dockerfile" = "#458588"
+"docker-compose.yml" = "#458588"
+"Makefile" = "#FB4934"
+"CMakeLists.txt" = "#FB4934"
+"README.md" = "#B8BB26"
+"LICENSE" = "#B8BB26"
+"package.json" = "#B8BB26"
+"Cargo.toml" = "#FB4934"
+"go.mod" = "#458588"
+"flake.nix" = "#B8BB26"
+"flake.lock" = "#3C3836"
+"shell.nix" = "#B8BB26"
+"default.nix" = "#B8BB26"
+
+[special_files.patterns]
+"*rc" = "#458588"
+"*.min.*" = "#3C3836"
+"*.test.*" = "#98971A"
+"*.spec.*" = "#98971A"
+"*.lock" = "#3C3836"
+"*.config.*" = "#458588"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FB4934"
+python = "#98971A"
+javascript = "#FABD2F"
+typescript = "#83A598"
+java = "#FB4934"
+csharp = "#98971A"
+cpp = "#FB4934"
+go = "#83A598"
+ruby = "#FB4934"
+php = "#98971A"
+swift = "#FB4934"
+kotlin = "#98971A"
+nix = "#83A598"
+
+markup = "#D3869B"
+style = "#98971A"
+web_config = "#B8BB26"
+
+shell = "#98971A"
+script = "#B8BB26"
+
+doc = "#EBDBB2"
+
+image = "#FE8019"
+video = "#FE8019"
+audio = "#FE8019"
+
+data = "#B8BB26"
+archive = "#FB4934"
+
+rs = "#FB4934"
+py = "#98971A"
+js = "#FABD2F"
+ts = "#83A598"
+jsx = "#FABD2F"
+tsx = "#83A598"
+vue = "#98971A"
+css = "#98971A"
+scss = "#98971A"
+html = "#D3869B"
+md = "#EBDBB2"
+json = "#B8BB26"
+yaml = "#B8BB26"
+toml = "#B8BB26"
+sql = "#83A598"

--- a/themes/light.toml
+++ b/themes/light.toml
@@ -1,86 +1,74 @@
-# lla light theme
 name = "light"
 author = "Mohamed Achaq"
 description = "A clean theme optimized for light terminals with carefully selected colors for maximum readability"
 
 [colors]
-# Core UI Elements
-file = { r = 71, g = 85, b = 105 }       # Slate gray for readability
-directory = { r = 30, g = 64, b = 175 }  # Dark blue
-symlink = { r = 2, g = 132, b = 199 }    # Deep blue
-executable = { r = 22, g = 163, b = 74 } # Forest green
+file = { r = 71, g = 85, b = 105 }
+directory = { r = 30, g = 64, b = 175 }
+symlink = { r = 2, g = 132, b = 199 }
+executable = { r = 22, g = 163, b = 74 }
 
-# Metadata
-size = { r = 22, g = 163, b = 74 }    # Forest green
-date = { r = 124, g = 58, b = 237 }   # Deep purple
-user = { r = 190, g = 24, b = 93 }    # Deep pink
-group = { r = 100, g = 116, b = 139 } # Cool gray
+size = { r = 22, g = 163, b = 74 }
+date = { r = 124, g = 58, b = 237 }
+user = { r = 190, g = 24, b = 93 }
+group = { r = 100, g = 116, b = 139 }
 
-# Permissions
-permission_dir = { r = 30, g = 64, b = 175 }    # Dark blue
-permission_read = { r = 22, g = 163, b = 74 }   # Forest green
-permission_write = { r = 194, g = 65, b = 12 }  # Burnt orange
-permission_exec = { r = 190, g = 24, b = 93 }   # Deep pink
-permission_none = { r = 148, g = 163, b = 184 } # Light gray
+permission_dir = { r = 30, g = 64, b = 175 }
+permission_read = { r = 22, g = 163, b = 74 }
+permission_write = { r = 194, g = 65, b = 12 }
+permission_exec = { r = 190, g = 24, b = 93 }
+permission_none = { r = 148, g = 163, b = 184 }
 
 [special_files]
-# Special Folders
 [special_files.folders]
-# Development folders
-"node_modules" = { r = 148, g = 163, b = 184 } # Light gray
-"target" = { r = 148, g = 163, b = 184 }       # Light gray
-"dist" = { r = 148, g = 163, b = 184 }         # Light gray
-".git" = { r = 190, g = 24, b = 93 }           # Deep pink
-"build" = { r = 148, g = 163, b = 184 }        # Light gray
-".cache" = { r = 148, g = 163, b = 184 }       # Light gray
+"node_modules" = { r = 148, g = 163, b = 184 }
+"target" = { r = 148, g = 163, b = 184 }
+"dist" = { r = 148, g = 163, b = 184 }
+".git" = { r = 190, g = 24, b = 93 }
+"build" = { r = 148, g = 163, b = 184 }
+".cache" = { r = 148, g = 163, b = 184 }
 
-# Environment folders
-"*-env" = { r = 22, g = 163, b = 74 } # Forest green
-"venv" = { r = 22, g = 163, b = 74 }  # Forest green
-".env" = { r = 22, g = 163, b = 74 }  # Forest green
+"*-env" = { r = 22, g = 163, b = 74 }
+"venv" = { r = 22, g = 163, b = 74 }
+".env" = { r = 22, g = 163, b = 74 }
 
-# Pattern matches for folders
-"*.d" = { r = 30, g = 64, b = 175 }       # Dark blue - Type definition folders
-"*_cache" = { r = 148, g = 163, b = 184 } # Light gray - Cache folders
-"*-cache" = { r = 148, g = 163, b = 184 } # Light gray - Cache folders
+"*.d" = { r = 30, g = 64, b = 175 }
+"*_cache" = { r = 148, g = 163, b = 184 }
+"*-cache" = { r = 148, g = 163, b = 184 }
 
-# Dotfiles
 [special_files.dotfiles]
-".gitignore" = { r = 2, g = 132, b = 199 }    # Deep blue
-".env" = { r = 194, g = 65, b = 12 }          # Burnt orange
-".dockerignore" = { r = 2, g = 132, b = 199 } # Deep blue
-".editorconfig" = { r = 2, g = 132, b = 199 } # Deep blue
-".prettierrc" = { r = 2, g = 132, b = 199 }   # Deep blue
-".eslintrc" = { r = 2, g = 132, b = 199 }     # Deep blue
-".babelrc" = { r = 2, g = 132, b = 199 }      # Deep blue
+".gitignore" = { r = 2, g = 132, b = 199 }
+".env" = { r = 194, g = 65, b = 12 }
+".dockerignore" = { r = 2, g = 132, b = 199 }
+".editorconfig" = { r = 2, g = 132, b = 199 }
+".prettierrc" = { r = 2, g = 132, b = 199 }
+".eslintrc" = { r = 2, g = 132, b = 199 }
+".babelrc" = { r = 2, g = 132, b = 199 }
 
-# Exact matches
 [special_files.exact_match]
-"Dockerfile" = { r = 2, g = 132, b = 199 }         # Deep blue
-"docker-compose.yml" = { r = 2, g = 132, b = 199 } # Deep blue
-"Makefile" = { r = 190, g = 24, b = 93 }           # Deep pink
-"CMakeLists.txt" = { r = 190, g = 24, b = 93 }     # Deep pink
-"README.md" = { r = 194, g = 65, b = 12 }          # Burnt orange
-"LICENSE" = { r = 194, g = 65, b = 12 }            # Burnt orange
-"package.json" = { r = 194, g = 65, b = 12 }       # Burnt orange
-"Cargo.toml" = { r = 190, g = 24, b = 93 }         # Deep pink
-"go.mod" = { r = 2, g = 132, b = 199 }             # Deep blue
-"flake.nix" = { r = 30, g = 64, b = 175 }          # Dark blue
-"flake.lock" = { r = 148, g = 163, b = 184 }       # Light gray
-"shell.nix" = { r = 30, g = 64, b = 175 }          # Dark blue
-"default.nix" = { r = 30, g = 64, b = 175 }        # Dark blue
+"Dockerfile" = { r = 2, g = 132, b = 199 }
+"docker-compose.yml" = { r = 2, g = 132, b = 199 }
+"Makefile" = { r = 190, g = 24, b = 93 }
+"CMakeLists.txt" = { r = 190, g = 24, b = 93 }
+"README.md" = { r = 194, g = 65, b = 12 }
+"LICENSE" = { r = 194, g = 65, b = 12 }
+"package.json" = { r = 194, g = 65, b = 12 }
+"Cargo.toml" = { r = 190, g = 24, b = 93 }
+"go.mod" = { r = 2, g = 132, b = 199 }
+"flake.nix" = { r = 30, g = 64, b = 175 }
+"flake.lock" = { r = 148, g = 163, b = 184 }
+"shell.nix" = { r = 30, g = 64, b = 175 }
+"default.nix" = { r = 30, g = 64, b = 175 }
 
-# Pattern matches
 [special_files.patterns]
-"*rc" = { r = 2, g = 132, b = 199 }        # Deep blue
-"*.min.*" = { r = 148, g = 163, b = 184 }  # Light gray
-"*.test.*" = { r = 22, g = 163, b = 74 }   # Forest green
-"*.spec.*" = { r = 22, g = 163, b = 74 }   # Forest green
-"*.lock" = { r = 148, g = 163, b = 184 }   # Light gray
-"*.config.*" = { r = 2, g = 132, b = 199 } # Deep blue
+"*rc" = { r = 2, g = 132, b = 199 }
+"*.min.*" = { r = 148, g = 163, b = 184 }
+"*.test.*" = { r = 22, g = 163, b = 74 }
+"*.spec.*" = { r = 22, g = 163, b = 74 }
+"*.lock" = { r = 148, g = 163, b = 184 }
+"*.config.*" = { r = 2, g = 132, b = 199 }
 
 [extensions.groups]
-# Development files
 rust = ["rs", "toml"]
 python = ["py", "pyi", "pyw", "ipynb"]
 javascript = ["js", "mjs", "cjs", "jsx"]
@@ -95,16 +83,13 @@ swift = ["swift"]
 kotlin = ["kt", "kts"]
 nix = ["nix"]
 
-# Web files
 markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
 style = ["css", "scss", "sass", "less", "styl"]
 web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
 
-# Shell and scripts
 shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
 script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
 
-# Documentation
 doc = [
     "md",
     "rst",
@@ -120,65 +105,56 @@ doc = [
     "rtf",
 ]
 
-# Media files
 image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
 video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
 audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
 
-# Data and config
 data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
 archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
 
 [extensions.colors]
-# Development
-rust = { r = 190, g = 24, b = 93 }       # Deep pink
-python = { r = 22, g = 163, b = 74 }     # Forest green
-javascript = { r = 194, g = 65, b = 12 } # Burnt orange
-typescript = { r = 30, g = 64, b = 175 } # Dark blue
-java = { r = 190, g = 24, b = 93 }       # Deep pink
-csharp = { r = 22, g = 163, b = 74 }     # Forest green
-cpp = { r = 190, g = 24, b = 93 }        # Deep pink
-go = { r = 2, g = 132, b = 199 }         # Deep blue
-ruby = { r = 190, g = 24, b = 93 }       # Deep pink
-php = { r = 22, g = 163, b = 74 }        # Forest green
-swift = { r = 190, g = 24, b = 93 }      # Deep pink
-kotlin = { r = 22, g = 163, b = 74 }     # Forest green
-nix = { r = 30, g = 64, b = 175 }        # Dark blue
+rust = { r = 190, g = 24, b = 93 }
+python = { r = 22, g = 163, b = 74 }
+javascript = { r = 194, g = 65, b = 12 }
+typescript = { r = 30, g = 64, b = 175 }
+java = { r = 190, g = 24, b = 93 }
+csharp = { r = 22, g = 163, b = 74 }
+cpp = { r = 190, g = 24, b = 93 }
+go = { r = 2, g = 132, b = 199 }
+ruby = { r = 190, g = 24, b = 93 }
+php = { r = 22, g = 163, b = 74 }
+swift = { r = 190, g = 24, b = 93 }
+kotlin = { r = 22, g = 163, b = 74 }
+nix = { r = 30, g = 64, b = 175 }
 
-# Web
-markup = { r = 124, g = 58, b = 237 }    # Deep purple
-style = { r = 2, g = 132, b = 199 }      # Deep blue
-web_config = { r = 194, g = 65, b = 12 } # Burnt orange
+markup = { r = 124, g = 58, b = 237 }
+style = { r = 2, g = 132, b = 199 }
+web_config = { r = 194, g = 65, b = 12 }
 
-# Shell and scripts
-shell = { r = 22, g = 163, b = 74 }  # Forest green
-script = { r = 194, g = 65, b = 12 } # Burnt orange
+shell = { r = 22, g = 163, b = 74 }
+script = { r = 194, g = 65, b = 12 }
 
-# Documentation
-doc = { r = 71, g = 85, b = 105 } # Slate gray
+doc = { r = 71, g = 85, b = 105 }
 
-# Media
-image = { r = 124, g = 58, b = 237 } # Deep purple
-video = { r = 124, g = 58, b = 237 } # Deep purple
-audio = { r = 124, g = 58, b = 237 } # Deep purple
+image = { r = 124, g = 58, b = 237 }
+video = { r = 124, g = 58, b = 237 }
+audio = { r = 124, g = 58, b = 237 }
 
-# Data and config
-data = { r = 194, g = 65, b = 12 }    # Burnt orange
-archive = { r = 190, g = 24, b = 93 } # Deep pink
+data = { r = 194, g = 65, b = 12 }
+archive = { r = 190, g = 24, b = 93 }
 
-# Individual extension overrides
-rs = { r = 190, g = 24, b = 93 }    # Deep pink
-py = { r = 22, g = 163, b = 74 }    # Forest green
-js = { r = 194, g = 65, b = 12 }    # Burnt orange
-ts = { r = 30, g = 64, b = 175 }    # Dark blue
-jsx = { r = 194, g = 65, b = 12 }   # Burnt orange
-tsx = { r = 30, g = 64, b = 175 }   # Dark blue
-vue = { r = 22, g = 163, b = 74 }   # Forest green
-css = { r = 2, g = 132, b = 199 }   # Deep blue
-scss = { r = 2, g = 132, b = 199 }  # Deep blue
-html = { r = 124, g = 58, b = 237 } # Deep purple
-md = { r = 71, g = 85, b = 105 }    # Slate gray
-json = { r = 194, g = 65, b = 12 }  # Burnt orange
-yaml = { r = 194, g = 65, b = 12 }  # Burnt orange
-toml = { r = 194, g = 65, b = 12 }  # Burnt orange
-sql = { r = 2, g = 132, b = 199 }   # Deep blue
+rs = { r = 190, g = 24, b = 93 }
+py = { r = 22, g = 163, b = 74 }
+js = { r = 194, g = 65, b = 12 }
+ts = { r = 30, g = 64, b = 175 }
+jsx = { r = 194, g = 65, b = 12 }
+tsx = { r = 30, g = 64, b = 175 }
+vue = { r = 22, g = 163, b = 74 }
+css = { r = 2, g = 132, b = 199 }
+scss = { r = 2, g = 132, b = 199 }
+html = { r = 124, g = 58, b = 237 }
+md = { r = 71, g = 85, b = 105 }
+json = { r = 194, g = 65, b = 12 }
+yaml = { r = 194, g = 65, b = 12 }
+toml = { r = 194, g = 65, b = 12 }
+sql = { r = 2, g = 132, b = 199 }

--- a/themes/light.toml
+++ b/themes/light.toml
@@ -1,0 +1,184 @@
+# lla light theme
+name = "light"
+author = "Mohamed Achaq"
+description = "A clean theme optimized for light terminals with carefully selected colors for maximum readability"
+
+[colors]
+# Core UI Elements
+file = { r = 71, g = 85, b = 105 }       # Slate gray for readability
+directory = { r = 30, g = 64, b = 175 }  # Dark blue
+symlink = { r = 2, g = 132, b = 199 }    # Deep blue
+executable = { r = 22, g = 163, b = 74 } # Forest green
+
+# Metadata
+size = { r = 22, g = 163, b = 74 }    # Forest green
+date = { r = 124, g = 58, b = 237 }   # Deep purple
+user = { r = 190, g = 24, b = 93 }    # Deep pink
+group = { r = 100, g = 116, b = 139 } # Cool gray
+
+# Permissions
+permission_dir = { r = 30, g = 64, b = 175 }    # Dark blue
+permission_read = { r = 22, g = 163, b = 74 }   # Forest green
+permission_write = { r = 194, g = 65, b = 12 }  # Burnt orange
+permission_exec = { r = 190, g = 24, b = 93 }   # Deep pink
+permission_none = { r = 148, g = 163, b = 184 } # Light gray
+
+[special_files]
+# Special Folders
+[special_files.folders]
+# Development folders
+"node_modules" = { r = 148, g = 163, b = 184 } # Light gray
+"target" = { r = 148, g = 163, b = 184 }       # Light gray
+"dist" = { r = 148, g = 163, b = 184 }         # Light gray
+".git" = { r = 190, g = 24, b = 93 }           # Deep pink
+"build" = { r = 148, g = 163, b = 184 }        # Light gray
+".cache" = { r = 148, g = 163, b = 184 }       # Light gray
+
+# Environment folders
+"*-env" = { r = 22, g = 163, b = 74 } # Forest green
+"venv" = { r = 22, g = 163, b = 74 }  # Forest green
+".env" = { r = 22, g = 163, b = 74 }  # Forest green
+
+# Pattern matches for folders
+"*.d" = { r = 30, g = 64, b = 175 }       # Dark blue - Type definition folders
+"*_cache" = { r = 148, g = 163, b = 184 } # Light gray - Cache folders
+"*-cache" = { r = 148, g = 163, b = 184 } # Light gray - Cache folders
+
+# Dotfiles
+[special_files.dotfiles]
+".gitignore" = { r = 2, g = 132, b = 199 }    # Deep blue
+".env" = { r = 194, g = 65, b = 12 }          # Burnt orange
+".dockerignore" = { r = 2, g = 132, b = 199 } # Deep blue
+".editorconfig" = { r = 2, g = 132, b = 199 } # Deep blue
+".prettierrc" = { r = 2, g = 132, b = 199 }   # Deep blue
+".eslintrc" = { r = 2, g = 132, b = 199 }     # Deep blue
+".babelrc" = { r = 2, g = 132, b = 199 }      # Deep blue
+
+# Exact matches
+[special_files.exact_match]
+"Dockerfile" = { r = 2, g = 132, b = 199 }         # Deep blue
+"docker-compose.yml" = { r = 2, g = 132, b = 199 } # Deep blue
+"Makefile" = { r = 190, g = 24, b = 93 }           # Deep pink
+"CMakeLists.txt" = { r = 190, g = 24, b = 93 }     # Deep pink
+"README.md" = { r = 194, g = 65, b = 12 }          # Burnt orange
+"LICENSE" = { r = 194, g = 65, b = 12 }            # Burnt orange
+"package.json" = { r = 194, g = 65, b = 12 }       # Burnt orange
+"Cargo.toml" = { r = 190, g = 24, b = 93 }         # Deep pink
+"go.mod" = { r = 2, g = 132, b = 199 }             # Deep blue
+"flake.nix" = { r = 30, g = 64, b = 175 }          # Dark blue
+"flake.lock" = { r = 148, g = 163, b = 184 }       # Light gray
+"shell.nix" = { r = 30, g = 64, b = 175 }          # Dark blue
+"default.nix" = { r = 30, g = 64, b = 175 }        # Dark blue
+
+# Pattern matches
+[special_files.patterns]
+"*rc" = { r = 2, g = 132, b = 199 }        # Deep blue
+"*.min.*" = { r = 148, g = 163, b = 184 }  # Light gray
+"*.test.*" = { r = 22, g = 163, b = 74 }   # Forest green
+"*.spec.*" = { r = 22, g = 163, b = 74 }   # Forest green
+"*.lock" = { r = 148, g = 163, b = 184 }   # Light gray
+"*.config.*" = { r = 2, g = 132, b = 199 } # Deep blue
+
+[extensions.groups]
+# Development files
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+# Web files
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+# Shell and scripts
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+# Documentation
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+# Media files
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+# Data and config
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+# Development
+rust = { r = 190, g = 24, b = 93 }       # Deep pink
+python = { r = 22, g = 163, b = 74 }     # Forest green
+javascript = { r = 194, g = 65, b = 12 } # Burnt orange
+typescript = { r = 30, g = 64, b = 175 } # Dark blue
+java = { r = 190, g = 24, b = 93 }       # Deep pink
+csharp = { r = 22, g = 163, b = 74 }     # Forest green
+cpp = { r = 190, g = 24, b = 93 }        # Deep pink
+go = { r = 2, g = 132, b = 199 }         # Deep blue
+ruby = { r = 190, g = 24, b = 93 }       # Deep pink
+php = { r = 22, g = 163, b = 74 }        # Forest green
+swift = { r = 190, g = 24, b = 93 }      # Deep pink
+kotlin = { r = 22, g = 163, b = 74 }     # Forest green
+nix = { r = 30, g = 64, b = 175 }        # Dark blue
+
+# Web
+markup = { r = 124, g = 58, b = 237 }    # Deep purple
+style = { r = 2, g = 132, b = 199 }      # Deep blue
+web_config = { r = 194, g = 65, b = 12 } # Burnt orange
+
+# Shell and scripts
+shell = { r = 22, g = 163, b = 74 }  # Forest green
+script = { r = 194, g = 65, b = 12 } # Burnt orange
+
+# Documentation
+doc = { r = 71, g = 85, b = 105 } # Slate gray
+
+# Media
+image = { r = 124, g = 58, b = 237 } # Deep purple
+video = { r = 124, g = 58, b = 237 } # Deep purple
+audio = { r = 124, g = 58, b = 237 } # Deep purple
+
+# Data and config
+data = { r = 194, g = 65, b = 12 }    # Burnt orange
+archive = { r = 190, g = 24, b = 93 } # Deep pink
+
+# Individual extension overrides
+rs = { r = 190, g = 24, b = 93 }    # Deep pink
+py = { r = 22, g = 163, b = 74 }    # Forest green
+js = { r = 194, g = 65, b = 12 }    # Burnt orange
+ts = { r = 30, g = 64, b = 175 }    # Dark blue
+jsx = { r = 194, g = 65, b = 12 }   # Burnt orange
+tsx = { r = 30, g = 64, b = 175 }   # Dark blue
+vue = { r = 22, g = 163, b = 74 }   # Forest green
+css = { r = 2, g = 132, b = 199 }   # Deep blue
+scss = { r = 2, g = 132, b = 199 }  # Deep blue
+html = { r = 124, g = 58, b = 237 } # Deep purple
+md = { r = 71, g = 85, b = 105 }    # Slate gray
+json = { r = 194, g = 65, b = 12 }  # Burnt orange
+yaml = { r = 194, g = 65, b = 12 }  # Burnt orange
+toml = { r = 194, g = 65, b = 12 }  # Burnt orange
+sql = { r = 2, g = 132, b = 199 }   # Deep blue

--- a/themes/material_ocean.toml
+++ b/themes/material_ocean.toml
@@ -1,0 +1,158 @@
+name = "material_ocean"
+author = "Mohamed Achaq"
+description = "A deep blue theme based on Material Design, featuring oceanic colors and excellent contrast"
+
+[colors]
+file = "#A6ACCD"
+directory = "#82AAFF"
+symlink = "#C792EA"
+executable = "#C3E88D"
+
+size = "#464B5D"
+date = "#464B5D"
+user = "#F07178"
+group = "#464B5D"
+
+permission_dir = "#82AAFF"
+permission_read = "#C3E88D"
+permission_write = "#F07178"
+permission_exec = "#FF5370"
+permission_none = "#1F2233"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#1F2233"
+"dist" = "#1F2233"
+".git" = "#82AAFF"
+"build" = "#1F2233"
+".cache" = "#1F2233"
+"*-env" = "#C3E88D"
+"venv" = "#C3E88D"
+".env" = "#C3E88D"
+"*.d" = "#C792EA"
+"*_cache" = "#1F2233"
+"*-cache" = "#1F2233"
+
+[special_files.dotfiles]
+".gitignore" = "#89DDFF"
+".env" = "#82AAFF"
+".dockerignore" = "#89DDFF"
+".editorconfig" = "#89DDFF"
+".prettierrc" = "#89DDFF"
+".eslintrc" = "#89DDFF"
+".babelrc" = "#89DDFF"
+
+[special_files.exact_match]
+"Dockerfile" = "#89DDFF"
+"docker-compose.yml" = "#89DDFF"
+"Makefile" = "#FF5370"
+"CMakeLists.txt" = "#FF5370"
+"README.md" = "#82AAFF"
+"LICENSE" = "#82AAFF"
+"package.json" = "#82AAFF"
+"Cargo.toml" = "#FF5370"
+"go.mod" = "#89DDFF"
+"flake.nix" = "#82AAFF"
+"flake.lock" = "#1F2233"
+"shell.nix" = "#82AAFF"
+"default.nix" = "#82AAFF"
+
+[special_files.patterns]
+"*rc" = "#89DDFF"
+"*.min.*" = "#1F2233"
+"*.test.*" = "#C3E88D"
+"*.spec.*" = "#C3E88D"
+"*.lock" = "#1F2233"
+"*.config.*" = "#89DDFF"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#FF5370"
+python = "#C3E88D"
+javascript = "#FFCB6B"
+typescript = "#89DDFF"
+java = "#FF5370"
+csharp = "#C3E88D"
+cpp = "#FF5370"
+go = "#89DDFF"
+ruby = "#FF5370"
+php = "#C3E88D"
+swift = "#FF5370"
+kotlin = "#C3E88D"
+nix = "#89DDFF"
+
+markup = "#C792EA"
+style = "#C3E88D"
+web_config = "#82AAFF"
+
+shell = "#C3E88D"
+script = "#82AAFF"
+
+doc = "#A6ACCD"
+
+image = "#F78C6C"
+video = "#F78C6C"
+audio = "#F78C6C"
+
+data = "#82AAFF"
+archive = "#FF5370"
+
+rs = "#FF5370"
+py = "#C3E88D"
+js = "#FFCB6B"
+ts = "#89DDFF"
+jsx = "#FFCB6B"
+tsx = "#89DDFF"
+vue = "#C3E88D"
+css = "#C3E88D"
+scss = "#C3E88D"
+html = "#C792EA"
+md = "#A6ACCD"
+json = "#82AAFF"
+yaml = "#82AAFF"
+toml = "#82AAFF"
+sql = "#89DDFF"

--- a/themes/material_ocean.toml
+++ b/themes/material_ocean.toml
@@ -17,22 +17,22 @@ permission_dir = "#82AAFF"
 permission_read = "#C3E88D"
 permission_write = "#F07178"
 permission_exec = "#FF5370"
-permission_none = "#1F2233"
+permission_none = "#464B5D"
 
 [special_files]
 [special_files.folders]
 "node_modules" = { h = 0, s = 0, l = 0.15 }
-"target" = "#1F2233"
-"dist" = "#1F2233"
+"target" = "#464B5D"
+"dist" = "#464B5D"
 ".git" = "#82AAFF"
-"build" = "#1F2233"
-".cache" = "#1F2233"
+"build" = "#464B5D"
+".cache" = "#464B5D"
 "*-env" = "#C3E88D"
 "venv" = "#C3E88D"
 ".env" = "#C3E88D"
 "*.d" = "#C792EA"
-"*_cache" = "#1F2233"
-"*-cache" = "#1F2233"
+"*_cache" = "#464B5D"
+"*-cache" = "#464B5D"
 
 [special_files.dotfiles]
 ".gitignore" = "#89DDFF"
@@ -54,16 +54,16 @@ permission_none = "#1F2233"
 "Cargo.toml" = "#FF5370"
 "go.mod" = "#89DDFF"
 "flake.nix" = "#82AAFF"
-"flake.lock" = "#1F2233"
+"flake.lock" = "#464B5D"
 "shell.nix" = "#82AAFF"
 "default.nix" = "#82AAFF"
 
 [special_files.patterns]
 "*rc" = "#89DDFF"
-"*.min.*" = "#1F2233"
+"*.min.*" = "#464B5D"
 "*.test.*" = "#C3E88D"
 "*.spec.*" = "#C3E88D"
-"*.lock" = "#1F2233"
+"*.lock" = "#464B5D"
 "*.config.*" = "#89DDFF"
 
 [extensions.groups]

--- a/themes/nord.toml
+++ b/themes/nord.toml
@@ -1,0 +1,158 @@
+name = "nord"
+author = "Mohamed Achaq"
+description = "An arctic, north-bluish color palette with elegant pastel colors and soothing tones"
+
+[colors]
+file = "#D8DEE9"
+directory = "#88C0D0"
+symlink = "#81A1C1"
+executable = "#A3BE8C"
+
+size = "#4C566A"
+date = "#4C566A"
+user = "#B48EAD"
+group = "#4C566A"
+
+permission_dir = "#88C0D0"
+permission_read = "#A3BE8C"
+permission_write = "#B48EAD"
+permission_exec = "#BF616A"
+permission_none = "#3B4252"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#3B4252"
+"dist" = "#3B4252"
+".git" = "#88C0D0"
+"build" = "#3B4252"
+".cache" = "#3B4252"
+"*-env" = "#A3BE8C"
+"venv" = "#A3BE8C"
+".env" = "#A3BE8C"
+"*.d" = "#81A1C1"
+"*_cache" = "#3B4252"
+"*-cache" = "#3B4252"
+
+[special_files.dotfiles]
+".gitignore" = "#5E81AC"
+".env" = "#88C0D0"
+".dockerignore" = "#5E81AC"
+".editorconfig" = "#5E81AC"
+".prettierrc" = "#5E81AC"
+".eslintrc" = "#5E81AC"
+".babelrc" = "#5E81AC"
+
+[special_files.exact_match]
+"Dockerfile" = "#5E81AC"
+"docker-compose.yml" = "#5E81AC"
+"Makefile" = "#BF616A"
+"CMakeLists.txt" = "#BF616A"
+"README.md" = "#88C0D0"
+"LICENSE" = "#88C0D0"
+"package.json" = "#88C0D0"
+"Cargo.toml" = "#BF616A"
+"go.mod" = "#5E81AC"
+"flake.nix" = "#88C0D0"
+"flake.lock" = "#3B4252"
+"shell.nix" = "#88C0D0"
+"default.nix" = "#88C0D0"
+
+[special_files.patterns]
+"*rc" = "#5E81AC"
+"*.min.*" = "#3B4252"
+"*.test.*" = "#A3BE8C"
+"*.spec.*" = "#A3BE8C"
+"*.lock" = "#3B4252"
+"*.config.*" = "#5E81AC"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#BF616A"
+python = "#A3BE8C"
+javascript = "#EBCB8B"
+typescript = "#81A1C1"
+java = "#BF616A"
+csharp = "#A3BE8C"
+cpp = "#BF616A"
+go = "#81A1C1"
+ruby = "#BF616A"
+php = "#A3BE8C"
+swift = "#BF616A"
+kotlin = "#A3BE8C"
+nix = "#81A1C1"
+
+markup = "#B48EAD"
+style = "#A3BE8C"
+web_config = "#88C0D0"
+
+shell = "#A3BE8C"
+script = "#88C0D0"
+
+doc = "#D8DEE9"
+
+image = "#D08770"
+video = "#D08770"
+audio = "#D08770"
+
+data = "#88C0D0"
+archive = "#BF616A"
+
+rs = "#BF616A"
+py = "#A3BE8C"
+js = "#EBCB8B"
+ts = "#81A1C1"
+jsx = "#EBCB8B"
+tsx = "#81A1C1"
+vue = "#A3BE8C"
+css = "#A3BE8C"
+scss = "#A3BE8C"
+html = "#B48EAD"
+md = "#D8DEE9"
+json = "#88C0D0"
+yaml = "#88C0D0"
+toml = "#88C0D0"
+sql = "#81A1C1"

--- a/themes/nord.toml
+++ b/themes/nord.toml
@@ -17,22 +17,22 @@ permission_dir = "#88C0D0"
 permission_read = "#A3BE8C"
 permission_write = "#B48EAD"
 permission_exec = "#BF616A"
-permission_none = "#3B4252"
+permission_none = "#4C566A"
 
 [special_files]
 [special_files.folders]
 "node_modules" = { h = 0, s = 0, l = 0.15 }
-"target" = "#3B4252"
-"dist" = "#3B4252"
+"target" = "#4C566A"
+"dist" = "#4C566A"
 ".git" = "#88C0D0"
-"build" = "#3B4252"
-".cache" = "#3B4252"
+"build" = "#4C566A"
+".cache" = "#4C566A"
 "*-env" = "#A3BE8C"
 "venv" = "#A3BE8C"
 ".env" = "#A3BE8C"
 "*.d" = "#81A1C1"
-"*_cache" = "#3B4252"
-"*-cache" = "#3B4252"
+"*_cache" = "#4C566A"
+"*-cache" = "#4C566A"
 
 [special_files.dotfiles]
 ".gitignore" = "#5E81AC"
@@ -54,16 +54,16 @@ permission_none = "#3B4252"
 "Cargo.toml" = "#BF616A"
 "go.mod" = "#5E81AC"
 "flake.nix" = "#88C0D0"
-"flake.lock" = "#3B4252"
+"flake.lock" = "#4C566A"
 "shell.nix" = "#88C0D0"
 "default.nix" = "#88C0D0"
 
 [special_files.patterns]
 "*rc" = "#5E81AC"
-"*.min.*" = "#3B4252"
+"*.min.*" = "#4C566A"
 "*.test.*" = "#A3BE8C"
 "*.spec.*" = "#A3BE8C"
-"*.lock" = "#3B4252"
+"*.lock" = "#4C566A"
 "*.config.*" = "#5E81AC"
 
 [extensions.groups]

--- a/themes/one_dark.toml
+++ b/themes/one_dark.toml
@@ -1,0 +1,158 @@
+name = "one_dark"
+author = "Mohamed Achaq"
+description = "A dark theme inspired by Atom, featuring a perfect balance of cool and warm colors"
+
+[colors]
+file = "#ABB2BF"
+directory = "#61AFEF"
+symlink = "#C678DD"
+executable = "#98C379"
+
+size = "#5C6370"
+date = "#5C6370"
+user = "#E06C75"
+group = "#5C6370"
+
+permission_dir = "#61AFEF"
+permission_read = "#98C379"
+permission_write = "#E06C75"
+permission_exec = "#E06C75"
+permission_none = "#282C34"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#282C34"
+"dist" = "#282C34"
+".git" = "#61AFEF"
+"build" = "#282C34"
+".cache" = "#282C34"
+"*-env" = "#98C379"
+"venv" = "#98C379"
+".env" = "#98C379"
+"*.d" = "#C678DD"
+"*_cache" = "#282C34"
+"*-cache" = "#282C34"
+
+[special_files.dotfiles]
+".gitignore" = "#56B6C2"
+".env" = "#61AFEF"
+".dockerignore" = "#56B6C2"
+".editorconfig" = "#56B6C2"
+".prettierrc" = "#56B6C2"
+".eslintrc" = "#56B6C2"
+".babelrc" = "#56B6C2"
+
+[special_files.exact_match]
+"Dockerfile" = "#56B6C2"
+"docker-compose.yml" = "#56B6C2"
+"Makefile" = "#E06C75"
+"CMakeLists.txt" = "#E06C75"
+"README.md" = "#61AFEF"
+"LICENSE" = "#61AFEF"
+"package.json" = "#61AFEF"
+"Cargo.toml" = "#E06C75"
+"go.mod" = "#56B6C2"
+"flake.nix" = "#61AFEF"
+"flake.lock" = "#282C34"
+"shell.nix" = "#61AFEF"
+"default.nix" = "#61AFEF"
+
+[special_files.patterns]
+"*rc" = "#56B6C2"
+"*.min.*" = "#282C34"
+"*.test.*" = "#98C379"
+"*.spec.*" = "#98C379"
+"*.lock" = "#282C34"
+"*.config.*" = "#56B6C2"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#E06C75"
+python = "#98C379"
+javascript = "#E5C07B"
+typescript = "#56B6C2"
+java = "#E06C75"
+csharp = "#98C379"
+cpp = "#E06C75"
+go = "#56B6C2"
+ruby = "#E06C75"
+php = "#98C379"
+swift = "#E06C75"
+kotlin = "#98C379"
+nix = "#56B6C2"
+
+markup = "#C678DD"
+style = "#98C379"
+web_config = "#61AFEF"
+
+shell = "#98C379"
+script = "#61AFEF"
+
+doc = "#ABB2BF"
+
+image = "#D19A66"
+video = "#D19A66"
+audio = "#D19A66"
+
+data = "#61AFEF"
+archive = "#E06C75"
+
+rs = "#E06C75"
+py = "#98C379"
+js = "#E5C07B"
+ts = "#56B6C2"
+jsx = "#E5C07B"
+tsx = "#56B6C2"
+vue = "#98C379"
+css = "#98C379"
+scss = "#98C379"
+html = "#C678DD"
+md = "#ABB2BF"
+json = "#61AFEF"
+yaml = "#61AFEF"
+toml = "#61AFEF"
+sql = "#56B6C2"

--- a/themes/one_dark.toml
+++ b/themes/one_dark.toml
@@ -17,22 +17,22 @@ permission_dir = "#61AFEF"
 permission_read = "#98C379"
 permission_write = "#E06C75"
 permission_exec = "#E06C75"
-permission_none = "#282C34"
+permission_none = "#5C6370"
 
 [special_files]
 [special_files.folders]
 "node_modules" = { h = 0, s = 0, l = 0.15 }
-"target" = "#282C34"
-"dist" = "#282C34"
+"target" = "#5C6370"
+"dist" = "#5C6370"
 ".git" = "#61AFEF"
-"build" = "#282C34"
-".cache" = "#282C34"
+"build" = "#5C6370"
+".cache" = "#5C6370"
 "*-env" = "#98C379"
 "venv" = "#98C379"
 ".env" = "#98C379"
 "*.d" = "#C678DD"
-"*_cache" = "#282C34"
-"*-cache" = "#282C34"
+"*_cache" = "#5C6370"
+"*-cache" = "#5C6370"
 
 [special_files.dotfiles]
 ".gitignore" = "#56B6C2"
@@ -54,16 +54,16 @@ permission_none = "#282C34"
 "Cargo.toml" = "#E06C75"
 "go.mod" = "#56B6C2"
 "flake.nix" = "#61AFEF"
-"flake.lock" = "#282C34"
+"flake.lock" = "#5C6370"
 "shell.nix" = "#61AFEF"
 "default.nix" = "#61AFEF"
 
 [special_files.patterns]
 "*rc" = "#56B6C2"
-"*.min.*" = "#282C34"
+"*.min.*" = "#5C6370"
 "*.test.*" = "#98C379"
 "*.spec.*" = "#98C379"
-"*.lock" = "#282C34"
+"*.lock" = "#5C6370"
 "*.config.*" = "#56B6C2"
 
 [extensions.groups]

--- a/themes/poimandres.toml
+++ b/themes/poimandres.toml
@@ -1,82 +1,72 @@
-# lla poimandres theme
 name = "poimandres"
 author = "Mohamed Achaq"
 description = "A theme inspired by the Poimandres color scheme, featuring a deep space aesthetic with vibrant accents"
 
 [colors]
-# Core UI Elements
-file = "#A6ACAE"       # foreground - Soft gray for files
-directory = "#89AFFF"  # blue - Directories
-symlink = "#89DBFF"    # cyan - Symlinks
-executable = "#5DE4B3" # green - Executables
+file = "#A6ACAE"
+directory = "#89AFFF"
+symlink = "#89DBFF"
+executable = "#5DE4B3"
 
-# Metadata
-size = "#5DE4B3"  # green - File sizes
-date = "#FCBCFA"  # magenta - Dates
-user = "#D0679D"  # red - User
-group = "#8A9092" # dim-foreground - Group
+size = "#5DE4B3"
+date = "#FCBCFA"
+user = "#D0679D"
+group = "#A6ACAE"
 
-# Permissions
-permission_dir = "#89AFFF"   # blue - Directory permissions
-permission_read = "#5DE4B3"  # green - Read permissions
-permission_write = "#FFFFC2" # yellow - Write permissions
-permission_exec = "#D0679D"  # red - Execute permissions
-permission_none = "#282E30"  # dim-black - No permissions
+permission_dir = "#89AFFF"
+permission_read = "#5DE4B3"
+permission_write = "#FFFFC2"
+permission_exec = "#D0679D"
+permission_none = "#A6ACAE"
 
 [special_files]
-# Special Folders
 [special_files.folders]
-# Development folders
-"node_modules" = { h = 0, s = 0, l = 0.3 } # Dark gray using HSL
-"target" = "#282E30"                       # dim-black
-"dist" = "#282E30"                         # dim-black
-".git" = "#D0679D"                         # red
-"build" = "#282E30"                        # dim-black
-".cache" = "#282E30"                       # dim-black
-"*-env" = "#5DE4B3"                        # green
-"venv" = "#5DE4B3"                         # green
-".env" = "#5DE4B3"                         # green
-"*.d" = "#89AFFF"                          # blue - Type definition folders
-"*_cache" = "#282E30"                      # dim-black - Cache folders
-"*-cache" = "#282E30"                      # dim-black - Cache folders
+"node_modules" = { h = 0, s = 0, l = 0.3 }
+"target" = "#A6ACAE"
+"dist" = "#A6ACAE"
+".git" = "#D0679D"
+"build" = "#A6ACAE"
+".cache" = "#A6ACAE"
+"*-env" = "#5DE4B3"
+"venv" = "#5DE4B3"
+".env" = "#5DE4B3"
+"*.d" = "#89AFFF"
+"*_cache" = "#A6ACAE"
+"*-cache" = "#A6ACAE"
 
-# Dotfiles
 [special_files.dotfiles]
-".gitignore" = "#89DBFF"    # cyan
-".env" = "#FFFFC2"          # yellow
-".dockerignore" = "#89DBFF" # cyan
-".editorconfig" = "#89DBFF" # cyan
-".prettierrc" = "#89DBFF"   # cyan
-".eslintrc" = "#89DBFF"     # cyan
-".babelrc" = "#89DBFF"      # cyan
+".gitignore" = "#89DBFF"
+".env" = "#FFFFC2"
+".dockerignore" = "#89DBFF"
+".editorconfig" = "#89DBFF"
+".prettierrc" = "#89DBFF"
+".eslintrc" = "#89DBFF"
+".babelrc" = "#89DBFF"
 
-# Exact matches
 [special_files.exact_match]
-"Dockerfile" = "#89DBFF"         # cyan
-"docker-compose.yml" = "#89DBFF" # cyan
-"Makefile" = "#D0679D"           # red
-"CMakeLists.txt" = "#D0679D"     # red
-"README.md" = "#FFFFC2"          # yellow
-"LICENSE" = "#FFFFC2"            # yellow
-"package.json" = "#FFFFC2"       # yellow
-"Cargo.toml" = "#D0679D"         # red
-"go.mod" = "#89DBFF"             # cyan
-"flake.nix" = "#89AFFF"          # blue
-"flake.lock" = "#282E30"         # dim-black
-"shell.nix" = "#89AFFF"          # blue
-"default.nix" = "#89AFFF"        # blue
+"Dockerfile" = "#89DBFF"
+"docker-compose.yml" = "#89DBFF"
+"Makefile" = "#D0679D"
+"CMakeLists.txt" = "#D0679D"
+"README.md" = "#FFFFC2"
+"LICENSE" = "#FFFFC2"
+"package.json" = "#FFFFC2"
+"Cargo.toml" = "#D0679D"
+"go.mod" = "#89DBFF"
+"flake.nix" = "#89AFFF"
+"flake.lock" = "#A6ACAE"
+"shell.nix" = "#89AFFF"
+"default.nix" = "#89AFFF"
 
-# Pattern matches
 [special_files.patterns]
-"*rc" = "#89DBFF"        # cyan
-"*.min.*" = "#282E30"    # dim-black
-"*.test.*" = "#5DE4B3"   # green
-"*.spec.*" = "#5DE4B3"   # green
-"*.lock" = "#282E30"     # dim-black
-"*.config.*" = "#89DBFF" # cyan
+"*rc" = "#89DBFF"
+"*.min.*" = "#A6ACAE"
+"*.test.*" = "#5DE4B3"
+"*.spec.*" = "#5DE4B3"
+"*.lock" = "#A6ACAE"
+"*.config.*" = "#89DBFF"
 
 [extensions.groups]
-# Development files
 rust = ["rs", "toml"]
 python = ["py", "pyi", "pyw", "ipynb"]
 javascript = ["js", "mjs", "cjs", "jsx"]
@@ -91,16 +81,13 @@ swift = ["swift"]
 kotlin = ["kt", "kts"]
 nix = ["nix"]
 
-# Web files
 markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
 style = ["css", "scss", "sass", "less", "styl"]
 web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
 
-# Shell and scripts
 shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
 script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
 
-# Documentation
 doc = [
     "md",
     "rst",
@@ -116,65 +103,56 @@ doc = [
     "rtf",
 ]
 
-# Media files
 image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
 video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
 audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
 
-# Data and config
 data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
 archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
 
 [extensions.colors]
-# Development
-rust = "#D0679D"       # red
-python = "#5DE4B3"     # green
-javascript = "#FFFFC2" # yellow
-typescript = "#89AFFF" # blue
-java = "#D0679D"       # red
-csharp = "#5DE4B3"     # green
-cpp = "#D0679D"        # red
-go = "#89DBFF"         # cyan
-ruby = "#D0679D"       # red
-php = "#5DE4B3"        # green
-swift = "#D0679D"      # red
-kotlin = "#5DE4B3"     # green
-nix = "#89DBFF"        # cyan
+rust = "#D0679D"
+python = "#5DE4B3"
+javascript = "#FFFFC2"
+typescript = "#89AFFF"
+java = "#D0679D"
+csharp = "#5DE4B3"
+cpp = "#D0679D"
+go = "#89DBFF"
+ruby = "#D0679D"
+php = "#5DE4B3"
+swift = "#D0679D"
+kotlin = "#5DE4B3"
+nix = "#89DBFF"
 
-# Web
-markup = "#FCBCFA"     # magenta
-style = "#89DBFF"      # cyan
-web_config = "#FFFFC2" # yellow
+markup = "#FCBCFA"
+style = "#89DBFF"
+web_config = "#FFFFC2"
 
-# Shell and scripts
-shell = "#5DE4B3"  # green
-script = "#FFFFC2" # yellow
+shell = "#5DE4B3"
+script = "#FFFFC2"
 
-# Documentation
-doc = "#A6ACAE" # foreground
+doc = "#A6ACAE"
 
-# Media
-image = "#FCBCFA" # magenta
-video = "#FCBCFA" # magenta
-audio = "#FCBCFA" # magenta
+image = "#FCBCFA"
+video = "#FCBCFA"
+audio = "#FCBCFA"
 
-# Data and config
-data = "#FFFFC2"    # yellow
-archive = "#D0679D" # red
+data = "#FFFFC2"
+archive = "#D0679D"
 
-# Individual extension overrides
-rs = "#D0679D"   # red
-py = "#5DE4B3"   # green
-js = "#FFFFC2"   # yellow
-ts = "#89AFFF"   # blue
-jsx = "#FFFFC2"  # yellow
-tsx = "#89AFFF"  # blue
-vue = "#5DE4B3"  # green
-css = "#89DBFF"  # cyan
-scss = "#89DBFF" # cyan
-html = "#FCBCFA" # magenta
-md = "#A6ACAE"   # foreground
-json = "#FFFFC2" # yellow
-yaml = "#FFFFC2" # yellow
-toml = "#FFFFC2" # yellow
-sql = "#89DBFF"  # cyan
+rs = "#D0679D"
+py = "#5DE4B3"
+js = "#FFFFC2"
+ts = "#89AFFF"
+jsx = "#FFFFC2"
+tsx = "#89AFFF"
+vue = "#5DE4B3"
+css = "#89DBFF"
+scss = "#89DBFF"
+html = "#FCBCFA"
+md = "#A6ACAE"
+json = "#FFFFC2"
+yaml = "#FFFFC2"
+toml = "#FFFFC2"
+sql = "#89DBFF"

--- a/themes/poimandres.toml
+++ b/themes/poimandres.toml
@@ -1,0 +1,180 @@
+# lla poimandres theme
+name = "poimandres"
+author = "Mohamed Achaq"
+description = "A theme inspired by the Poimandres color scheme, featuring a deep space aesthetic with vibrant accents"
+
+[colors]
+# Core UI Elements
+file = "#A6ACAE"       # foreground - Soft gray for files
+directory = "#89AFFF"  # blue - Directories
+symlink = "#89DBFF"    # cyan - Symlinks
+executable = "#5DE4B3" # green - Executables
+
+# Metadata
+size = "#5DE4B3"  # green - File sizes
+date = "#FCBCFA"  # magenta - Dates
+user = "#D0679D"  # red - User
+group = "#8A9092" # dim-foreground - Group
+
+# Permissions
+permission_dir = "#89AFFF"   # blue - Directory permissions
+permission_read = "#5DE4B3"  # green - Read permissions
+permission_write = "#FFFFC2" # yellow - Write permissions
+permission_exec = "#D0679D"  # red - Execute permissions
+permission_none = "#282E30"  # dim-black - No permissions
+
+[special_files]
+# Special Folders
+[special_files.folders]
+# Development folders
+"node_modules" = { h = 0, s = 0, l = 0.3 } # Dark gray using HSL
+"target" = "#282E30"                       # dim-black
+"dist" = "#282E30"                         # dim-black
+".git" = "#D0679D"                         # red
+"build" = "#282E30"                        # dim-black
+".cache" = "#282E30"                       # dim-black
+"*-env" = "#5DE4B3"                        # green
+"venv" = "#5DE4B3"                         # green
+".env" = "#5DE4B3"                         # green
+"*.d" = "#89AFFF"                          # blue - Type definition folders
+"*_cache" = "#282E30"                      # dim-black - Cache folders
+"*-cache" = "#282E30"                      # dim-black - Cache folders
+
+# Dotfiles
+[special_files.dotfiles]
+".gitignore" = "#89DBFF"    # cyan
+".env" = "#FFFFC2"          # yellow
+".dockerignore" = "#89DBFF" # cyan
+".editorconfig" = "#89DBFF" # cyan
+".prettierrc" = "#89DBFF"   # cyan
+".eslintrc" = "#89DBFF"     # cyan
+".babelrc" = "#89DBFF"      # cyan
+
+# Exact matches
+[special_files.exact_match]
+"Dockerfile" = "#89DBFF"         # cyan
+"docker-compose.yml" = "#89DBFF" # cyan
+"Makefile" = "#D0679D"           # red
+"CMakeLists.txt" = "#D0679D"     # red
+"README.md" = "#FFFFC2"          # yellow
+"LICENSE" = "#FFFFC2"            # yellow
+"package.json" = "#FFFFC2"       # yellow
+"Cargo.toml" = "#D0679D"         # red
+"go.mod" = "#89DBFF"             # cyan
+"flake.nix" = "#89AFFF"          # blue
+"flake.lock" = "#282E30"         # dim-black
+"shell.nix" = "#89AFFF"          # blue
+"default.nix" = "#89AFFF"        # blue
+
+# Pattern matches
+[special_files.patterns]
+"*rc" = "#89DBFF"        # cyan
+"*.min.*" = "#282E30"    # dim-black
+"*.test.*" = "#5DE4B3"   # green
+"*.spec.*" = "#5DE4B3"   # green
+"*.lock" = "#282E30"     # dim-black
+"*.config.*" = "#89DBFF" # cyan
+
+[extensions.groups]
+# Development files
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+# Web files
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+# Shell and scripts
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+# Documentation
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+# Media files
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+# Data and config
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+# Development
+rust = "#D0679D"       # red
+python = "#5DE4B3"     # green
+javascript = "#FFFFC2" # yellow
+typescript = "#89AFFF" # blue
+java = "#D0679D"       # red
+csharp = "#5DE4B3"     # green
+cpp = "#D0679D"        # red
+go = "#89DBFF"         # cyan
+ruby = "#D0679D"       # red
+php = "#5DE4B3"        # green
+swift = "#D0679D"      # red
+kotlin = "#5DE4B3"     # green
+nix = "#89DBFF"        # cyan
+
+# Web
+markup = "#FCBCFA"     # magenta
+style = "#89DBFF"      # cyan
+web_config = "#FFFFC2" # yellow
+
+# Shell and scripts
+shell = "#5DE4B3"  # green
+script = "#FFFFC2" # yellow
+
+# Documentation
+doc = "#A6ACAE" # foreground
+
+# Media
+image = "#FCBCFA" # magenta
+video = "#FCBCFA" # magenta
+audio = "#FCBCFA" # magenta
+
+# Data and config
+data = "#FFFFC2"    # yellow
+archive = "#D0679D" # red
+
+# Individual extension overrides
+rs = "#D0679D"   # red
+py = "#5DE4B3"   # green
+js = "#FFFFC2"   # yellow
+ts = "#89AFFF"   # blue
+jsx = "#FFFFC2"  # yellow
+tsx = "#89AFFF"  # blue
+vue = "#5DE4B3"  # green
+css = "#89DBFF"  # cyan
+scss = "#89DBFF" # cyan
+html = "#FCBCFA" # magenta
+md = "#A6ACAE"   # foreground
+json = "#FFFFC2" # yellow
+yaml = "#FFFFC2" # yellow
+toml = "#FFFFC2" # yellow
+sql = "#89DBFF"  # cyan

--- a/themes/tokyo_night.toml
+++ b/themes/tokyo_night.toml
@@ -1,0 +1,158 @@
+name = "tokyo_night"
+author = "Mohamed Achaq"
+description = "A dark theme inspired by the vibrant lights of Tokyo at night, featuring deep blues and bright accents"
+
+[colors]
+file = "#A9B1D6"
+directory = "#7AA2F7"
+symlink = "#BB9AF7"
+executable = "#9ECE6A"
+
+size = "#565F89"
+date = "#565F89"
+user = "#F7768E"
+group = "#565F89"
+
+permission_dir = "#7AA2F7"
+permission_read = "#9ECE6A"
+permission_write = "#F7768E"
+permission_exec = "#F7768E"
+permission_none = "#1A1B26"
+
+[special_files]
+[special_files.folders]
+"node_modules" = { h = 0, s = 0, l = 0.15 }
+"target" = "#1A1B26"
+"dist" = "#1A1B26"
+".git" = "#7AA2F7"
+"build" = "#1A1B26"
+".cache" = "#1A1B26"
+"*-env" = "#9ECE6A"
+"venv" = "#9ECE6A"
+".env" = "#9ECE6A"
+"*.d" = "#BB9AF7"
+"*_cache" = "#1A1B26"
+"*-cache" = "#1A1B26"
+
+[special_files.dotfiles]
+".gitignore" = "#2AC3DE"
+".env" = "#7AA2F7"
+".dockerignore" = "#2AC3DE"
+".editorconfig" = "#2AC3DE"
+".prettierrc" = "#2AC3DE"
+".eslintrc" = "#2AC3DE"
+".babelrc" = "#2AC3DE"
+
+[special_files.exact_match]
+"Dockerfile" = "#2AC3DE"
+"docker-compose.yml" = "#2AC3DE"
+"Makefile" = "#F7768E"
+"CMakeLists.txt" = "#F7768E"
+"README.md" = "#7AA2F7"
+"LICENSE" = "#7AA2F7"
+"package.json" = "#7AA2F7"
+"Cargo.toml" = "#F7768E"
+"go.mod" = "#2AC3DE"
+"flake.nix" = "#7AA2F7"
+"flake.lock" = "#1A1B26"
+"shell.nix" = "#7AA2F7"
+"default.nix" = "#7AA2F7"
+
+[special_files.patterns]
+"*rc" = "#2AC3DE"
+"*.min.*" = "#1A1B26"
+"*.test.*" = "#9ECE6A"
+"*.spec.*" = "#9ECE6A"
+"*.lock" = "#1A1B26"
+"*.config.*" = "#2AC3DE"
+
+[extensions.groups]
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+rust = "#F7768E"
+python = "#9ECE6A"
+javascript = "#E0AF68"
+typescript = "#2AC3DE"
+java = "#F7768E"
+csharp = "#9ECE6A"
+cpp = "#F7768E"
+go = "#2AC3DE"
+ruby = "#F7768E"
+php = "#9ECE6A"
+swift = "#F7768E"
+kotlin = "#9ECE6A"
+nix = "#2AC3DE"
+
+markup = "#BB9AF7"
+style = "#9ECE6A"
+web_config = "#7AA2F7"
+
+shell = "#9ECE6A"
+script = "#7AA2F7"
+
+doc = "#A9B1D6"
+
+image = "#FF9E64"
+video = "#FF9E64"
+audio = "#FF9E64"
+
+data = "#7AA2F7"
+archive = "#F7768E"
+
+rs = "#F7768E"
+py = "#9ECE6A"
+js = "#E0AF68"
+ts = "#2AC3DE"
+jsx = "#E0AF68"
+tsx = "#2AC3DE"
+vue = "#9ECE6A"
+css = "#9ECE6A"
+scss = "#9ECE6A"
+html = "#BB9AF7"
+md = "#A9B1D6"
+json = "#7AA2F7"
+yaml = "#7AA2F7"
+toml = "#7AA2F7"
+sql = "#2AC3DE"

--- a/themes/tokyo_night.toml
+++ b/themes/tokyo_night.toml
@@ -17,22 +17,22 @@ permission_dir = "#7AA2F7"
 permission_read = "#9ECE6A"
 permission_write = "#F7768E"
 permission_exec = "#F7768E"
-permission_none = "#1A1B26"
+permission_none = "#565F89"
 
 [special_files]
 [special_files.folders]
 "node_modules" = { h = 0, s = 0, l = 0.15 }
-"target" = "#1A1B26"
-"dist" = "#1A1B26"
+"target" = "#565F89"
+"dist" = "#565F89"
 ".git" = "#7AA2F7"
-"build" = "#1A1B26"
-".cache" = "#1A1B26"
+"build" = "#565F89"
+".cache" = "#565F89"
 "*-env" = "#9ECE6A"
 "venv" = "#9ECE6A"
 ".env" = "#9ECE6A"
 "*.d" = "#BB9AF7"
-"*_cache" = "#1A1B26"
-"*-cache" = "#1A1B26"
+"*_cache" = "#565F89"
+"*-cache" = "#565F89"
 
 [special_files.dotfiles]
 ".gitignore" = "#2AC3DE"
@@ -54,16 +54,16 @@ permission_none = "#1A1B26"
 "Cargo.toml" = "#F7768E"
 "go.mod" = "#2AC3DE"
 "flake.nix" = "#7AA2F7"
-"flake.lock" = "#1A1B26"
+"flake.lock" = "#565F89"
 "shell.nix" = "#7AA2F7"
 "default.nix" = "#7AA2F7"
 
 [special_files.patterns]
 "*rc" = "#2AC3DE"
-"*.min.*" = "#1A1B26"
+"*.min.*" = "#565F89"
 "*.test.*" = "#9ECE6A"
 "*.spec.*" = "#9ECE6A"
-"*.lock" = "#1A1B26"
+"*.lock" = "#565F89"
 "*.config.*" = "#2AC3DE"
 
 [extensions.groups]

--- a/themes/vesper.toml
+++ b/themes/vesper.toml
@@ -1,82 +1,72 @@
-# lla vesper theme
 name = "vesper"
 author = "Mohamed Achaq"
 description = "A minimalist dark theme with warm accents, inspired by the Vesper color scheme"
 
 [colors]
-# Core UI Elements
-file = "#FFFFFF"       # White for files - good contrast
-directory = "#FFC799"  # Warm orange - Directories
-symlink = "#99FFE4"    # Cyan - Symlinks
-executable = "#99FFE4" # Cyan - Executables
+file = "#FFFFFF"
+directory = "#FFC799"
+symlink = "#99FFE4"
+executable = "#99FFE4"
 
-# Metadata
-size = "#A0A0A0"  # Gray - File sizes
-date = "#A0A0A0"  # Gray - Dates
-user = "#FFC799"  # Warm orange - User
-group = "#7E7E7E" # Dim gray - Group
+size = "#A0A0A0"
+date = "#A0A0A0"
+user = "#FFC799"
+group = "#7E7E7E"
 
-# Permissions
-permission_dir = "#FFC799"   # Warm orange - Directory permissions
-permission_read = "#99FFE4"  # Cyan - Read permissions
-permission_write = "#FFC799" # Warm orange - Write permissions
-permission_exec = "#FF8080"  # Red - Execute permissions
-permission_none = "#505050"  # Dark gray - No permissions
+permission_dir = "#FFC799"
+permission_read = "#99FFE4"
+permission_write = "#FFC799"
+permission_exec = "#FF8080"
+permission_none = "#505050"
 
 [special_files]
-# Special Folders
 [special_files.folders]
-# Development folders
-"node_modules" = { h = 0, s = 0, l = 0.3 } # Dark gray using HSL
-"target" = "#232323"                       # Dark background
-"dist" = "#232323"                         # Dark background
-".git" = "#FFC799"                         # Warm orange
-"build" = "#232323"                        # Dark background
-".cache" = "#232323"                       # Dark background
-"*-env" = "#99FFE4"                        # Cyan
-"venv" = "#99FFE4"                         # Cyan
-".env" = "#99FFE4"                         # Cyan
-"*.d" = "#FFC799"                          # Warm orange - Type definition folders
-"*_cache" = "#232323"                      # Dark background - Cache folders
-"*-cache" = "#232323"                      # Dark background - Cache folders
+"node_modules" = { h = 0, s = 0, l = 0.3 }
+"target" = "#7E7E7E"
+"dist" = "#7E7E7E"
+".git" = "#FFC799"
+"build" = "#7E7E7E"
+".cache" = "#7E7E7E"
+"*-env" = "#99FFE4"
+"venv" = "#99FFE4"
+".env" = "#99FFE4"
+"*.d" = "#FFC799"
+"*_cache" = "#7E7E7E"
+"*-cache" = "#7E7E7E"
 
-# Dotfiles
 [special_files.dotfiles]
-".gitignore" = "#99FFE4"    # Cyan
-".env" = "#FFC799"          # Warm orange
-".dockerignore" = "#99FFE4" # Cyan
-".editorconfig" = "#99FFE4" # Cyan
-".prettierrc" = "#99FFE4"   # Cyan
-".eslintrc" = "#99FFE4"     # Cyan
-".babelrc" = "#99FFE4"      # Cyan
+".gitignore" = "#99FFE4"
+".env" = "#FFC799"
+".dockerignore" = "#99FFE4"
+".editorconfig" = "#99FFE4"
+".prettierrc" = "#99FFE4"
+".eslintrc" = "#99FFE4"
+".babelrc" = "#99FFE4"
 
-# Exact matches
 [special_files.exact_match]
-"Dockerfile" = "#99FFE4"         # Cyan
-"docker-compose.yml" = "#99FFE4" # Cyan
-"Makefile" = "#FF8080"           # Red
-"CMakeLists.txt" = "#FF8080"     # Red
-"README.md" = "#FFC799"          # Warm orange
-"LICENSE" = "#FFC799"            # Warm orange
-"package.json" = "#FFC799"       # Warm orange
-"Cargo.toml" = "#FF8080"         # Red
-"go.mod" = "#99FFE4"             # Cyan
-"flake.nix" = "#FFC799"          # Warm orange
-"flake.lock" = "#232323"         # Dark background
-"shell.nix" = "#FFC799"          # Warm orange
-"default.nix" = "#FFC799"        # Warm orange
+"Dockerfile" = "#99FFE4"
+"docker-compose.yml" = "#99FFE4"
+"Makefile" = "#FF8080"
+"CMakeLists.txt" = "#FF8080"
+"README.md" = "#FFC799"
+"LICENSE" = "#FFC799"
+"package.json" = "#FFC799"
+"Cargo.toml" = "#FF8080"
+"go.mod" = "#99FFE4"
+"flake.nix" = "#FFC799"
+"flake.lock" = "#7E7E7E"
+"shell.nix" = "#FFC799"
+"default.nix" = "#FFC799"
 
-# Pattern matches
 [special_files.patterns]
-"*rc" = "#99FFE4"        # Cyan
-"*.min.*" = "#232323"    # Dark background
-"*.test.*" = "#99FFE4"   # Cyan
-"*.spec.*" = "#99FFE4"   # Cyan
-"*.lock" = "#232323"     # Dark background
-"*.config.*" = "#99FFE4" # Cyan
+"*rc" = "#99FFE4"
+"*.min.*" = "#7E7E7E"
+"*.test.*" = "#99FFE4"
+"*.spec.*" = "#99FFE4"
+"*.lock" = "#7E7E7E"
+"*.config.*" = "#99FFE4"
 
 [extensions.groups]
-# Development files
 rust = ["rs", "toml"]
 python = ["py", "pyi", "pyw", "ipynb"]
 javascript = ["js", "mjs", "cjs", "jsx"]
@@ -91,16 +81,13 @@ swift = ["swift"]
 kotlin = ["kt", "kts"]
 nix = ["nix"]
 
-# Web files
 markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
 style = ["css", "scss", "sass", "less", "styl"]
 web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
 
-# Shell and scripts
 shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
 script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
 
-# Documentation
 doc = [
     "md",
     "rst",
@@ -116,65 +103,56 @@ doc = [
     "rtf",
 ]
 
-# Media files
 image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
 video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
 audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
 
-# Data and config
 data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
 archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
 
 [extensions.colors]
-# Development
-rust = "#FF8080"       # Red
-python = "#99FFE4"     # Cyan
-javascript = "#FFC799" # Warm orange
-typescript = "#FFC799" # Warm orange
-java = "#FF8080"       # Red
-csharp = "#99FFE4"     # Cyan
-cpp = "#FF8080"        # Red
-go = "#99FFE4"         # Cyan
-ruby = "#FF8080"       # Red
-php = "#99FFE4"        # Cyan
-swift = "#FF8080"      # Red
-kotlin = "#99FFE4"     # Cyan
-nix = "#99FFE4"        # Cyan
+rust = "#FF8080"
+python = "#99FFE4"
+javascript = "#FFC799"
+typescript = "#FFC799"
+java = "#FF8080"
+csharp = "#99FFE4"
+cpp = "#FF8080"
+go = "#99FFE4"
+ruby = "#FF8080"
+php = "#99FFE4"
+swift = "#FF8080"
+kotlin = "#99FFE4"
+nix = "#99FFE4"
 
-# Web
-markup = "#FFFFFF"     # White
-style = "#99FFE4"      # Cyan
-web_config = "#FFC799" # Warm orange
+markup = "#FFFFFF"
+style = "#99FFE4"
+web_config = "#FFC799"
 
-# Shell and scripts
-shell = "#99FFE4"  # Cyan
-script = "#FFC799" # Warm orange
+shell = "#99FFE4"
+script = "#FFC799"
 
-# Documentation
-doc = "#FFFFFF" # White
+doc = "#FFFFFF"
 
-# Media
-image = "#FFFFFF" # White
-video = "#FFFFFF" # White
-audio = "#FFFFFF" # White
+image = "#FFFFFF"
+video = "#FFFFFF"
+audio = "#FFFFFF"
 
-# Data and config
-data = "#FFC799"    # Warm orange
-archive = "#FF8080" # Red
+data = "#FFC799"
+archive = "#FF8080"
 
-# Individual extension overrides
-rs = "#FF8080"   # Red
-py = "#99FFE4"   # Cyan
-js = "#FFC799"   # Warm orange
-ts = "#FFC799"   # Warm orange
-jsx = "#FFC799"  # Warm orange
-tsx = "#FFC799"  # Warm orange
-vue = "#99FFE4"  # Cyan
-css = "#99FFE4"  # Cyan
-scss = "#99FFE4" # Cyan
-html = "#FFFFFF" # White
-md = "#FFFFFF"   # White
-json = "#FFC799" # Warm orange
-yaml = "#FFC799" # Warm orange
-toml = "#FFC799" # Warm orange
-sql = "#99FFE4"  # Cyan
+rs = "#FF8080"
+py = "#99FFE4"
+js = "#FFC799"
+ts = "#FFC799"
+jsx = "#FFC799"
+tsx = "#FFC799"
+vue = "#99FFE4"
+css = "#99FFE4"
+scss = "#99FFE4"
+html = "#FFFFFF"
+md = "#FFFFFF"
+json = "#FFC799"
+yaml = "#FFC799"
+toml = "#FFC799"
+sql = "#99FFE4"

--- a/themes/vesper.toml
+++ b/themes/vesper.toml
@@ -1,0 +1,180 @@
+# lla vesper theme
+name = "vesper"
+author = "Mohamed Achaq"
+description = "A minimalist dark theme with warm accents, inspired by the Vesper color scheme"
+
+[colors]
+# Core UI Elements
+file = "#FFFFFF"       # White for files - good contrast
+directory = "#FFC799"  # Warm orange - Directories
+symlink = "#99FFE4"    # Cyan - Symlinks
+executable = "#99FFE4" # Cyan - Executables
+
+# Metadata
+size = "#A0A0A0"  # Gray - File sizes
+date = "#A0A0A0"  # Gray - Dates
+user = "#FFC799"  # Warm orange - User
+group = "#7E7E7E" # Dim gray - Group
+
+# Permissions
+permission_dir = "#FFC799"   # Warm orange - Directory permissions
+permission_read = "#99FFE4"  # Cyan - Read permissions
+permission_write = "#FFC799" # Warm orange - Write permissions
+permission_exec = "#FF8080"  # Red - Execute permissions
+permission_none = "#505050"  # Dark gray - No permissions
+
+[special_files]
+# Special Folders
+[special_files.folders]
+# Development folders
+"node_modules" = { h = 0, s = 0, l = 0.3 } # Dark gray using HSL
+"target" = "#232323"                       # Dark background
+"dist" = "#232323"                         # Dark background
+".git" = "#FFC799"                         # Warm orange
+"build" = "#232323"                        # Dark background
+".cache" = "#232323"                       # Dark background
+"*-env" = "#99FFE4"                        # Cyan
+"venv" = "#99FFE4"                         # Cyan
+".env" = "#99FFE4"                         # Cyan
+"*.d" = "#FFC799"                          # Warm orange - Type definition folders
+"*_cache" = "#232323"                      # Dark background - Cache folders
+"*-cache" = "#232323"                      # Dark background - Cache folders
+
+# Dotfiles
+[special_files.dotfiles]
+".gitignore" = "#99FFE4"    # Cyan
+".env" = "#FFC799"          # Warm orange
+".dockerignore" = "#99FFE4" # Cyan
+".editorconfig" = "#99FFE4" # Cyan
+".prettierrc" = "#99FFE4"   # Cyan
+".eslintrc" = "#99FFE4"     # Cyan
+".babelrc" = "#99FFE4"      # Cyan
+
+# Exact matches
+[special_files.exact_match]
+"Dockerfile" = "#99FFE4"         # Cyan
+"docker-compose.yml" = "#99FFE4" # Cyan
+"Makefile" = "#FF8080"           # Red
+"CMakeLists.txt" = "#FF8080"     # Red
+"README.md" = "#FFC799"          # Warm orange
+"LICENSE" = "#FFC799"            # Warm orange
+"package.json" = "#FFC799"       # Warm orange
+"Cargo.toml" = "#FF8080"         # Red
+"go.mod" = "#99FFE4"             # Cyan
+"flake.nix" = "#FFC799"          # Warm orange
+"flake.lock" = "#232323"         # Dark background
+"shell.nix" = "#FFC799"          # Warm orange
+"default.nix" = "#FFC799"        # Warm orange
+
+# Pattern matches
+[special_files.patterns]
+"*rc" = "#99FFE4"        # Cyan
+"*.min.*" = "#232323"    # Dark background
+"*.test.*" = "#99FFE4"   # Cyan
+"*.spec.*" = "#99FFE4"   # Cyan
+"*.lock" = "#232323"     # Dark background
+"*.config.*" = "#99FFE4" # Cyan
+
+[extensions.groups]
+# Development files
+rust = ["rs", "toml"]
+python = ["py", "pyi", "pyw", "ipynb"]
+javascript = ["js", "mjs", "cjs", "jsx"]
+typescript = ["ts", "tsx", "d.ts"]
+java = ["java", "jar", "class"]
+csharp = ["cs", "csx"]
+cpp = ["cpp", "cc", "cxx", "c++", "hpp", "hxx", "h++"]
+go = ["go"]
+ruby = ["rb", "erb"]
+php = ["php", "phtml"]
+swift = ["swift"]
+kotlin = ["kt", "kts"]
+nix = ["nix"]
+
+# Web files
+markup = ["html", "htm", "xhtml", "xml", "svg", "vue", "wasm", "ejs"]
+style = ["css", "scss", "sass", "less", "styl"]
+web_config = ["json", "json5", "yaml", "yml", "toml", "ini", "conf", "config"]
+
+# Shell and scripts
+shell = ["sh", "bash", "zsh", "fish", "ps1", "psm1", "psd1"]
+script = ["pl", "pm", "t", "tcl", "lua", "vim", "vimrc", "r"]
+
+# Documentation
+doc = [
+    "md",
+    "rst",
+    "txt",
+    "org",
+    "wiki",
+    "adoc",
+    "tex",
+    "pdf",
+    "epub",
+    "doc",
+    "docx",
+    "rtf",
+]
+
+# Media files
+image = ["png", "jpg", "jpeg", "gif", "bmp", "tiff", "webp", "ico", "heic"]
+video = ["mp4", "webm", "mov", "avi", "mkv", "flv", "wmv", "m4v", "3gp"]
+audio = ["mp3", "wav", "ogg", "m4a", "flac", "aac", "wma"]
+
+# Data and config
+data = ["csv", "tsv", "sql", "sqlite", "db", "json", "xml", "yaml", "yml"]
+archive = ["zip", "tar", "gz", "bz2", "xz", "7z", "rar", "iso", "dmg"]
+
+[extensions.colors]
+# Development
+rust = "#FF8080"       # Red
+python = "#99FFE4"     # Cyan
+javascript = "#FFC799" # Warm orange
+typescript = "#FFC799" # Warm orange
+java = "#FF8080"       # Red
+csharp = "#99FFE4"     # Cyan
+cpp = "#FF8080"        # Red
+go = "#99FFE4"         # Cyan
+ruby = "#FF8080"       # Red
+php = "#99FFE4"        # Cyan
+swift = "#FF8080"      # Red
+kotlin = "#99FFE4"     # Cyan
+nix = "#99FFE4"        # Cyan
+
+# Web
+markup = "#FFFFFF"     # White
+style = "#99FFE4"      # Cyan
+web_config = "#FFC799" # Warm orange
+
+# Shell and scripts
+shell = "#99FFE4"  # Cyan
+script = "#FFC799" # Warm orange
+
+# Documentation
+doc = "#FFFFFF" # White
+
+# Media
+image = "#FFFFFF" # White
+video = "#FFFFFF" # White
+audio = "#FFFFFF" # White
+
+# Data and config
+data = "#FFC799"    # Warm orange
+archive = "#FF8080" # Red
+
+# Individual extension overrides
+rs = "#FF8080"   # Red
+py = "#99FFE4"   # Cyan
+js = "#FFC799"   # Warm orange
+ts = "#FFC799"   # Warm orange
+jsx = "#FFC799"  # Warm orange
+tsx = "#FFC799"  # Warm orange
+vue = "#99FFE4"  # Cyan
+css = "#99FFE4"  # Cyan
+scss = "#99FFE4" # Cyan
+html = "#FFFFFF" # White
+md = "#FFFFFF"   # White
+json = "#FFC799" # Warm orange
+yaml = "#FFC799" # Warm orange
+toml = "#FFC799" # Warm orange
+sql = "#99FFE4"  # Cyan


### PR DESCRIPTION
This pull request includes significant updates to the CI/CD workflows, the addition of a theming system, and enhancements to the command-line arguments for the `lla` tool. The most important changes include the creation of new workflows for different package managers, the introduction of a theming system in the `README.md`, and the addition of a `--no-color` option in the command-line arguments.

### CI/CD Workflow Updates:
* [`.github/workflows/package-managers.yml`](diffhunk://#diff-87375afde4b7a0ae5cead0f2ca26fe5dcab8341835789d0611e2642bcfc25227R1-R191): Added new workflows for MacPorts, Scoop, Winget, and Nix package managers to automate the distribution of the `lla` tool.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R78-R88): Added Windows builds and updated the `Prepare binary` step to handle Windows-specific file extensions. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R78-R88) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R126-R130)

### Theming System:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34): Introduced a new section on theming, detailing the structure of theme files, built-in themes, and instructions on how to use and customize themes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R472-R545) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R560-R563)

### Command-line Arguments Enhancements:
* [`lla/src/commands/args.rs`](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R16): Added a new `no_color` field to the `Args` struct and implemented the `--no-color` command-line argument to disable colored output. [[1]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R16) [[2]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R77) [[3]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R164-R168) [[4]](diffhunk://#diff-7ee069a02ec6297c808194fffe965bbc044aafea6a4bb9735202a34f3335d5d1R428)
* [`lla/src/commands/command_handler.rs`](diffhunk://#diff-74f52fd02e56961489dfa7c03f2b6caf4110d78db2fdccc9ce0a466a0cedca1dR8): Updated the `handle_command` and `handle_shortcut_action` functions to respect the `no_color` setting. [[1]](diffhunk://#diff-74f52fd02e56961489dfa7c03f2b6caf4110d78db2fdccc9ce0a466a0cedca1dR8) [[2]](diffhunk://#diff-74f52fd02e56961489dfa7c03f2b6caf4110d78db2fdccc9ce0a466a0cedca1dR17-R23) [[3]](diffhunk://#diff-74f52fd02e56961489dfa7c03f2b6caf4110d78db2fdccc9ce0a466a0cedca1dL35-R58) [[4]](diffhunk://#diff-74f52fd02e56961489dfa7c03f2b6caf4110d78db2fdccc9ce0a466a0cedca1dR67-R77) [[5]](diffhunk://#diff-74f52fd02e56961489dfa7c03f2b6caf4110d78db2fdccc9ce0a466a0cedca1dR86-R101) [[6]](diffhunk://#diff-74f52fd02e56961489dfa7c03f2b6caf4110d78db2fdccc9ce0a466a0cedca1dR116-R128)