### PR TITLE
fix: dupe import

### DIFF
--- a/lla/src/utils/color.rs
+++ b/lla/src/utils/color.rs
@@ -250,7 +250,6 @@ fn get_extension_color(path: &Path) -> Option<Color> {
     if is_no_color() {
         return None;
     }
-    use crate::theme::get_file_color;
     get_file_color(path)
 }
 


### PR DESCRIPTION
When I was building the project locally I spotted a compiler warning: `get_file_color is already imported`

Removed this (seemingly) dupe import, rebuilt, and then called the new binary (`./target/debug/lla`) and everything worked as I'd expect it to.

This is my first time working with Rust, so apologies in advance for any mistakes/misunderstandings!

Also, noticed that you're using conventional commits (feat, refactor, fix, docs). Are these tags defined anywhere in the docs?
