### PR TITLE
chore: update lla_plugin_interface dependency version to 0.3.8 

### DIFF
--- a/lla_plugin_utils/Cargo.toml
+++ b/lla_plugin_utils/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-lla_plugin_interface = { path = "../lla_plugin_interface" }
+lla_plugin_interface = { path = "../lla_plugin_interface", version = "0.3.8" }
 serde = { workspace = true }
 colored = { workspace = true }
 toml = { workspace = true }


### PR DESCRIPTION
This pull request includes a version update for a dependency in the `lla_plugin_utils` package. The change specifies the version of the `lla_plugin_interface` dependency in the `Cargo.toml` file.

Dependency update:

* [`lla_plugin_utils/Cargo.toml`](diffhunk://#diff-d35c569dca69accd0bce8b4743f2ad1f9738d9298179b262b838c4b4401454aaL10-R10): Updated the `lla_plugin_interface` dependency to version "0.3.8".